### PR TITLE
Restriction for the config parser to a delimiter

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/samba_util/__init__.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/samba_util/__init__.py
@@ -9,7 +9,7 @@ from .dns import *
 
 
 # Load samba domain
-smbconf = ConfigParser()
+smbconf = ConfigParser(delimiters=("=",))
 SAMBA_DOMAIN, SAMBA_REALM, SAMBA_NETBIOS, SAMBA_WORKGROUP = [''] * 4
 
 def parse_log_level(level):


### PR DESCRIPTION
If there are some special samba options in use, the script could not read all options. This commit restrict the config parser to only use "=" as a delimiter for the smb.conf.