### PR TITLE
Allow self-signed certificates for ldap connection

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/connector.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/connector.py
@@ -51,6 +51,7 @@ class LdapConnector:
         conn = ldap.initialize("ldaps://localhost:636/")
         conn.set_option(ldap.OPT_REFERRALS, 0)
         conn.set_option(ldap.OPT_RESTART, ldap.OPT_ON)
+        conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
         conn.protocol_version = ldap.VERSION3
 
         if not webui_import:

--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/models/lmnuser.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/models/lmnuser.py
@@ -241,6 +241,7 @@ class LMNUserModel(LMNModel):
         l = ldap.initialize("ldaps://localhost:636/")
         l.set_option(ldap.OPT_REFERRALS, 0)
         l.set_option(ldap.OPT_RESTART, ldap.OPT_ON)
+        l.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
         l.protocol_version = ldap.VERSION3
 
         try:


### PR DESCRIPTION
The ldap bind for the password test at https://github.com/linuxmuster/linuxmuster-tools/blob/5f7de04e0d647d881141828bba6d222a9c29097f/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/models/lmnuser.py#L237-L250 failed if the server has a self-sign certificate. 

We have two options to fix this:

1. Ignore self-signed certificates (see PR)
2. Move to unsecure ldap and port 389

The error occurs by requesting the `/api/v1/auth/` api endpoint. Please write me if you need the whole stacktrace.

Regards, Lukas