### PR TITLE
Fix logic for accumulating parent DNs in fill_members

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/writers/schoolclass.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/writers/schoolclass.py
@@ -99,7 +99,10 @@ class LMNSchoolclassGroup(LMNGroupCommon):
             for student in self.schoolclass_data['sophomorixMembers']:
                 parents_dn = self.lr.getval(f'/units/{student}-parents', 'member')
                 if parents_dn:
-                    members = parents_dn
+                    for dn in parents_dn:
+                        if dn not in members:
+                            members.append(dn)
+
 
         elif self.type == 'teachers':
             for member_dn in self.schoolclass_data['member']:


### PR DESCRIPTION
Corrected the logic for accumulating parent DNs in the fill_members function for school classes and prevent duplicate member entries.