### PR TITLE
Provide the LINBO helpers expected by the current sync endpoints

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/config.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/config.py
@@ -1,41 +1,58 @@
-import os
+import hashlib
 import locale
+import logging
+import os
 import time
-from glob import glob
 from datetime import datetime
+from pathlib import Path
 
 from .models import *
+from ._validation import check_linbo_conf_name
+from .hosts import get_mtime
 from ..devices import Devices
 
 
 LINBO_PATH = '/srv/linbo'
+logger = logging.getLogger(__name__)
+
+
+def _validate_safe_name(name: str) -> str:
+    """Validate a LINBO-safe config name and return it unchanged."""
+    if not isinstance(name, str) or not name:
+        raise ValueError('LINBO config name must not be empty')
+    if not check_linbo_conf_name(name):
+        raise ValueError(f'Unsafe LINBO config name: {name}')
+    return name
 
 class LinboConfigManager:
 
-    def __init__(self, school='default-school'):
+    def __init__(self, school='default-school', linbo_dir=LINBO_PATH):
         self.school = school
+        self.linbo_dir = Path(linbo_dir)
         self.linbo_configs = {}
 
         self.load_linbo_config()
 
     def load_linbo_config(self):
-        for config in glob('/srv/linbo/start.conf.*'):
-            if not os.path.islink(config):
-                group = config.replace('/srv/linbo/start.conf.', '')
+        self.linbo_configs = {}
+        for config in sorted(self.linbo_dir.glob('start.conf.*')):
+            if not config.is_symlink():
+                group = config.name.removeprefix('start.conf.')
                 try:
                     self.linbo_configs[group] = self.read_linbo_config(config)
                 except TypeError as e:
-                    logging.error(f"Failed to load {config}: {e}")
+                    logger.error(f"Failed to load {config}: {e}")
 
     def read_linbo_config(self, config):
-        if not os.path.isfile(config):
+        config = Path(config)
+        if not config.is_file():
             raise FileNotFoundError(f'Linbo config file not found: {config}.')
 
-        with open(config, 'r') as f:
-            kwargs = {'config': config}
+        with config.open('r', encoding='utf-8') as f:
+            kwargs = {'config': str(config)}
             current_model = ''
 
-            lc = LinboConfig(path=config, LINBO=None, Partitions=[], OS=[])
+            lc = LinboConfig(path=str(config), LINBO=None, Partitions=[], OS=[])
 
             for line in f:
                 line = line.split('#')[0].strip()
@@ -62,6 +79,51 @@ class LinboConfigManager:
 
     def linbo_groups(self):
         return list(self.linbo_configs.keys())
+
+    def list_startconf_ids(self) -> list[str]:
+        """Return sorted start.conf IDs from the LINBO directory."""
+        ids = []
+        for conf_path in sorted(self.linbo_dir.glob('start.conf.*')):
+            if conf_path.is_symlink():
+                continue
+            group_id = conf_path.name.removeprefix('start.conf.')
+            if group_id and check_linbo_conf_name(group_id):
+                ids.append(group_id)
+        return ids
+
+    def get_raw_startconfs(self, ids: list[str]) -> list[dict]:
+        """Return raw start.conf contents, hashes, and mtimes for the requested IDs."""
+        results = []
+        for group_id in ids:
+            try:
+                safe_id = _validate_safe_name(group_id)
+            except ValueError:
+                continue
+
+            conf_path = self.linbo_dir / f'start.conf.{safe_id}'
+            if not conf_path.is_file():
+                continue
+
+            try:
+                content = conf_path.read_text(encoding='utf-8')
+            except OSError:
+                continue
+
+            mtime = get_mtime(conf_path)
+            results.append({
+                'id': safe_id,
+                'content': content,
+                'hash': hashlib.sha256(content.encode()).hexdigest(),
+                'updatedAt': mtime.isoformat() if mtime else None,
+            })
+
+        return results
+
+    def get_startconf_mtime(self, group_id: str):
+        """Return the mtime of a specific start.conf file, or None if missing."""
+        safe_id = _validate_safe_name(group_id)
+        conf_path = self.linbo_dir / f'start.conf.{safe_id}'
+        return get_mtime(conf_path)
 
 ## The following functions need to be rewritten
 ## Still used in lmncli

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -2,9 +2,12 @@ import os
 import shutil
 import subprocess
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
+import re
 
 from ..lmnfile import LMNFile
+from ._validation import check_linbo_image_name
 
 
 logger = logging.getLogger(__name__)
@@ -528,3 +531,98 @@ class LinboImageManager:
                 imageGroup.backups[date].save_extras(data)
             else:
                 imageGroup.base.save_extras(data)
+
+
+_IMAGE_EXTS = {".qcow2", ".qdiff", ".cloop"}
+_IMAGE_SIDECARS = [".md5", ".info", ".desc", ".torrent", ".macct", ".reg", ".prestart", ".postsync"]
+
+
+def parse_info_file(info_path) -> dict:
+    """Parse a .info sidecar file into a dict of key=value pairs."""
+    result = {}
+    try:
+        path_obj = Path(info_path)
+        for line in path_obj.read_text(encoding="utf-8").splitlines():
+            match = re.match(r'^(\w+)="(.*)"', line)
+            if match:
+                result[match.group(1)] = match.group(2)
+    except OSError:
+        pass
+    return result
+
+
+def _resolve_sidecar_candidates(image_file: Path, base_name: str, sidecar_ext: str) -> list[Path]:
+    return [
+        image_file.with_suffix(image_file.suffix + sidecar_ext),
+        image_file.parent / f"{base_name}{sidecar_ext}",
+    ]
+
+
+def scan_images(images_dir: str = LINBO_PATH) -> list[dict]:
+    """Scan LINBO image directories for image-manifest data."""
+    images_path = Path(images_dir)
+    images = []
+    if not images_path.is_dir():
+        return images
+
+    for subdir in sorted(images_path.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith("."):
+            continue
+        if not check_linbo_image_name(subdir.name):
+            continue
+
+        for image_file in sorted(subdir.iterdir()):
+            if image_file.suffix not in _IMAGE_EXTS or not image_file.is_file():
+                continue
+            if "backups" in image_file.parts:
+                continue
+
+            stat = image_file.stat()
+            base_name = subdir.name
+            filename = image_file.name
+            rel_path = f"images/{base_name}/{filename}"
+
+            md5 = None
+            try:
+                md5 = image_file.with_suffix(image_file.suffix + ".md5").read_text(encoding="utf-8").strip().split()[0]
+            except OSError:
+                pass
+
+            info = parse_info_file(image_file.with_suffix(image_file.suffix + ".info"))
+
+            description = None
+            try:
+                description = image_file.with_suffix(image_file.suffix + ".desc").read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+
+            sidecars = []
+            files = [{"name": filename, "size": stat.st_size, "type": "image"}]
+            for sidecar_ext in _IMAGE_SIDECARS:
+                for candidate in _resolve_sidecar_candidates(image_file, base_name, sidecar_ext):
+                    if not candidate.is_file():
+                        continue
+                    sidecars.append(sidecar_ext.lstrip("."))
+                    sidecar_stat = candidate.stat()
+                    files.append({
+                        "name": candidate.name,
+                        "size": sidecar_stat.st_size,
+                        "type": "sidecar",
+                    })
+                    break
+
+            images.append({
+                "name": filename,
+                "filename": filename,
+                "base": base_name,
+                "path": rel_path,
+                "size": stat.st_size,
+                "md5": md5,
+                "info": info if info else None,
+                "description": description,
+                "sidecars": sidecars,
+                "files": files,
+                "updatedAt": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            })
+
+    return images


### PR DESCRIPTION
Extend the existing config and image modules with the start.conf accessors and image manifest scanner that the current LINBO API router and change tracker already call.

The change stays inside the maintainer's current module layout: no package import magic, no API-side workaround, and no broader refactor of the legacy helper functions.

Constraint: The current linuxmuster-api router already depends on these helpers in linuxmusterTools.linbo
Directive: Keep config.py as the canonical home for start.conf listing/raw access helpers used by changes.py and the API router
Tested: python3 -m py_compile on config.py and images.py; targeted helper smoke tests; make deb
Not-tested: Installation on a clean LMN server and end-to-end Docker sync against that server