### PR TITLE
Allow dots in usernames in LDAP router URLs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+linuxmuster-tools7 (7.4.7) lmn74; urgency=medium
+
+  * Allow dots in usernames in the LDAP router URL patterns.
+
+ -- Lukas Spitznagel <lukas.spitznagel@netzint.de>  Fri, 26 Jun 2026 15:11:10 +0200
+
 linuxmuster-tools7 (7.4.6) lmn74; urgency=medium
 
-  * Add configobj as dependency. 
+  * Add configobj as dependency.
 
  -- Arnaud Kientz <arnaud@linuxmuster.net>  Sun, 28 Jun 2026 11:21:43 +0200
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/pytests/test_router.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/pytests/test_router.py
@@ -14,6 +14,17 @@ class TestURLMatching:
         assert func.type == 'single'
         assert 'johndoe' in data.values()
 
+    def test_single_user_route_with_dot(self):
+        # Sophomorix may allow dots in usernames (e.g. firstname.lastname)
+        func, data = router._find_method('/users/peter.penis')
+        assert func.type == 'single'
+        assert data.get('username') == 'peter.penis'
+
+    def test_users_exam_collection_still_matches_with_dotted_user_route(self):
+        # The /users/exam collection must not be shadowed by the dotted user route
+        func, data = router._find_method('/users/exam')
+        assert func.type == 'collection'
+
     def test_user_search_route(self):
         func, data = router._find_method('/users/search/student/mueller')
         assert func.type == 'collection'

--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/admins.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/admins.py
@@ -18,7 +18,7 @@ def get_all_globaladministrators():
 
     return ldap_filter
 
-@router.single(r'/globaladministrators/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/globaladministrators/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_globaladministrator(username):
     """
     Get all details from a specific globaladministrator.
@@ -51,7 +51,7 @@ def get_all_schooladministrators():
 
     return ldap_filter
 
-@router.single(r'/schooladministrators/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/schooladministrators/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_schooladministrator(username):
     """
     Get all details from a specific schooladministrator.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/bindusers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/bindusers.py
@@ -18,7 +18,7 @@ def get_all_globalbindusers():
 
     return ldap_filter
 
-@router.single(r'/globalbindusers/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/globalbindusers/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_globalbinduser(username):
     """
     Get all details from a specific globalbinduser.
@@ -51,7 +51,7 @@ def get_all_schoolbindusers():
 
     return ldap_filter
 
-@router.single(r'/schoolbindusers/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/schoolbindusers/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_schoolbinduser(username):
     """
     Get all details from a specific schoolbinduser.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/users.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/ldapconnector/urls/users.py
@@ -40,7 +40,7 @@ def get_exam_users():
 
     return ldap_filter
 
-@router.single(r'/users/exam/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/users/exam/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_exam_user(username):
     """
     Get all details from a specific user in exam mode.
@@ -57,7 +57,7 @@ def get_exam_user(username):
 
     return ldap_filter
 
-@router.single(r'/users/(?P<username>[\w\-]*)', models.LMNUserModel)
+@router.single(r'/users/(?P<username>[\w\-.]*)', models.LMNUserModel)
 def get_user(username):
     """
     Get all details from a specific user.
@@ -138,7 +138,7 @@ def get_all_raw_users():
 
     return ldap_filter
 
-@router.single(r'/rawusers/(?P<username>[\w\-]*)', models.LMNRawUserModel)
+@router.single(r'/rawusers/(?P<username>[\w\-.]*)', models.LMNRawUserModel)
 def get_raw_user(username):
     """
     Get all details from a specific user.
@@ -160,7 +160,7 @@ def get_raw_user(username):
 
     return ldap_filter
 
-@router.collection(r'/batch_rawusers/(?P<usernames>[\w\-,]*)', models.LMNRawUserModel)
+@router.collection(r'/batch_rawusers/(?P<usernames>[\w\-,.]*)', models.LMNRawUserModel)
 def get_batch_raw_users(usernames):
     """
     Get all details from specific users: usernames should be a comma-separated
@@ -187,7 +187,7 @@ def get_batch_raw_users(usernames):
 
     return ldap_filter
 
-@router.collection(r'/batch_users/(?P<usernames>[\w\-,]*)', models.LMNUserModel)
+@router.collection(r'/batch_users/(?P<usernames>[\w\-,.]*)', models.LMNUserModel)
 def get_batch_users(usernames):
     """
     Get all details from specific users: usernames should be a comma-separated


### PR DESCRIPTION
Extend the URL regex patterns of the LDAP connector from `[\w\-]` to `[\w\-.]` so that usernames containing dots (e.g. `first.last`) are matched by the routes:

- `users`, `exam-users`, `rawusers` and their `batch_` variants
- `admins`
- `binduser`

Adds tests for dotted usernames and a changelog entry (7.4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)