### PR TITLE
Make ConfigLoader writes atomic

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/README.md
@@ -41,7 +41,7 @@ with LMNFile('/path/to/file.yml', 'r') as f:
 ### Parameters
 
 ```python
-LMNFile(file, mode, delimiter=';', fieldnames=None)
+LMNFile(file, mode, delimiter=';', fieldnames=None, convert_values=True)
 ```
 
 | Parameter | Type | Description |
@@ -50,6 +50,7 @@ LMNFile(file, mode, delimiter=';', fieldnames=None)
 | `mode` | `str` | Open mode: `'r'` (read), `'w'` (write), `'r+'` (read+write) |
 | `delimiter` | `str` | Delimiter for CSV files (default: `';'`) |
 | `fieldnames` | `list[str]` | Column names for CSV files without a header row |
+| `convert_values` | `bool` | Convert INI/conf values to Python types (default: `True`) |
 
 ---
 
@@ -121,6 +122,13 @@ String values are automatically converted on read:
 - Digit strings → `int`
 
 And converted back on write.
+
+Pass `convert_values=False` to preserve values such as `0012`, `yes` and `no`
+as strings when reading and writing.
+
+New INI/conf files created in write mode use permissions `0o600`. Replacing an
+existing file preserves its owner, group and permissions. Configuration
+symlinks stay intact while their resolved targets are updated atomically.
 
 ### Linbo start.conf
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/lmnfile.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/lmnfile.py
@@ -9,6 +9,8 @@ import abc
 import csv
 import magic
 import filecmp
+import stat
+import tempfile
 import time
 import yaml
 from configobj import ConfigObj
@@ -51,7 +53,9 @@ class LMNFile(metaclass=abc.ABCMeta):
     e.g. ini, csv, linbo config files.
     """
 
-    def __new__(cls, file, mode, delimiter=';', fieldnames=None):
+    def __new__(
+        cls, file, mode, delimiter=';', fieldnames=None, convert_values=True
+    ):
         """
         Parse the extension of the file and choose the right subclass to handle
         the file.
@@ -64,22 +68,32 @@ class LMNFile(metaclass=abc.ABCMeta):
         :type delimiter: string
         :param fieldnames: Useful for CSV files
         :type fieldnames: list of strings
+        :param convert_values: Convert ConfigLoader values to Python types
+        :type convert_values: bool
         """
 
         # Cannot filter start.conf with extension
         if file.split('/')[-1].startswith('start.conf') and os.path.splitext(file)[-1] != '.vdi':
             obj = object.__new__(StartConfLoader)
-            obj.__init__(file, mode, delimiter=delimiter, fieldnames=fieldnames)
+            obj.__init__(
+                file, mode, delimiter=delimiter, fieldnames=fieldnames,
+                convert_values=convert_values
+            )
             return obj
 
         ext = os.path.splitext(file)[-1]
         for child in cls.__subclasses__():
             if child.hasExtension(ext):
                 obj = object.__new__(child)
-                obj.__init__(file, mode, delimiter=delimiter, fieldnames=fieldnames)
+                obj.__init__(
+                    file, mode, delimiter=delimiter, fieldnames=fieldnames,
+                    convert_values=convert_values
+                )
                 return obj
 
-    def __init__(self, file, mode, delimiter=';', fieldnames=None):
+    def __init__(
+        self, file, mode, delimiter=';', fieldnames=None, convert_values=True
+    ):
         self.file = file
         self.opened = ''
         self.data = ''
@@ -88,6 +102,7 @@ class LMNFile(metaclass=abc.ABCMeta):
         self.comments = []
         self.check_allowed_path()
         self.delimiter = delimiter
+        self.convert_values = convert_values
         self.has_BOM = False
 
         if self.file.endswith('.csv'):
@@ -338,14 +353,22 @@ class ConfigLoader(LMNFile):
     extensions = ['.ini', '.conf']
 
     def __enter__(self):
-        self.opened = open(self.file, 'r', encoding=self.encoding)
-        if 'r' in self.mode or '+' in self.mode:
-            self.data = ConfigObj(
-                self.file, encoding='utf-8',
-                write_empty_values=True,
-                stringify=True,
-                list_values=False
-            )
+        if os.path.isfile(self.file):
+            self.opened = open(self.file, 'r', encoding=self.encoding)
+            source = self.file
+        elif 'w' in self.mode:
+            source = None
+        else:
+            raise FileNotFoundError(f'File {self.file} not found.')
+
+        self.data = ConfigObj(
+            source, encoding='utf-8',
+            write_empty_values=True,
+            stringify=True,
+            list_values=False
+        )
+        self.data.filename = self.file
+        if self.convert_values:
             for section, options in self.data.items():
                 for key, value in options.items():
                     value = int(value) if value.isdigit() else value
@@ -360,13 +383,38 @@ class ConfigLoader(LMNFile):
 
     def write(self, data):
         for section, options in data.items():
-                for key, value in options.items():
+            if section not in self.data:
+                self.data[section] = {}
+            for key, value in options.items():
+                if self.convert_values:
                     value = 'yes' if value is True else value
                     value = 'no' if value is False else value
-                    self.data[section][key] = value
+                self.data[section][key] = value
 
-        self.backup()
-        self.data.write()
+        # Replace the resolved target so an allowed configuration symlink keeps
+        # pointing to the same file instead of being replaced by a regular file.
+        target = os.path.realpath(self.file)
+        folder, name = os.path.split(target)
+        metadata = os.stat(target) if os.path.isfile(target) else None
+        fd, tmp = tempfile.mkstemp(prefix=f'.{name}.', suffix='.tmp', dir=folder)
+        try:
+            with os.fdopen(fd, 'wb') as f:
+                self.data.write(f)
+                f.flush()
+                os.fsync(f.fileno())
+
+            if metadata is not None:
+                # chown may clear setuid/setgid bits, so restore the complete
+                # permission mode afterwards.
+                os.chown(tmp, metadata.st_uid, metadata.st_gid)
+                os.chmod(tmp, stat.S_IMODE(metadata.st_mode))
+                self.backup()
+
+            os.replace(tmp, target)
+        except Exception:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
 
 class StartConfLoader(LMNFile):
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/pytests/test_config.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnfile/pytests/test_config.py
@@ -3,6 +3,9 @@ Tests for ConfigLoader: INI/conf parsing, type conversion on read/write,
 multi-section files.
 """
 
+import os
+import stat
+
 import pytest
 from linuxmusterTools.lmnfile import LMNFile
 
@@ -64,6 +67,18 @@ def test_read_multiple_values_in_section(tmp_path):
     assert data['setup']['enabled'] is True
 
 
+def test_read_without_value_conversion_preserves_strings(tmp_path):
+    content = '[setup]\ncode = 0012\nenabled = yes\ndisabled = no\n'
+    f = make_ini(tmp_path, content)
+
+    with LMNFile(str(f), 'r', convert_values=False) as lmn:
+        data = lmn.read()
+
+    assert data['setup']['code'] == '0012'
+    assert data['setup']['enabled'] == 'yes'
+    assert data['setup']['disabled'] == 'no'
+
+
 # ── Write ─────────────────────────────────────────────────────────────────────
 
 def test_write_string_value(tmp_path):
@@ -106,8 +121,21 @@ def test_write_int_value_preserved(tmp_path):
     assert result['setup']['port'] == 443
 
 
+def test_write_without_value_conversion_preserves_values(tmp_path):
+    f = make_ini(tmp_path, '[setup]\ncode = 0012\nenabled = yes\n')
+
+    with LMNFile(str(f), 'r', convert_values=False) as lmn:
+        data = lmn.read()
+        data['setup']['python_bool'] = True
+        lmn.write(data)
+
+    content = f.read_text(encoding='utf-8')
+    assert 'code = 0012' in content
+    assert 'enabled = yes' in content
+    assert 'python_bool = True' in content
+
+
 def test_write_creates_backup_on_change(tmp_path):
-    import os
     f = make_ini(tmp_path, '[school]\nname = Old\n')
     with LMNFile(str(f), 'r') as lmn:
         data = lmn.read()
@@ -115,6 +143,117 @@ def test_write_creates_backup_on_change(tmp_path):
         lmn.write(data)
     backups = [x for x in os.listdir(str(tmp_path)) if x.startswith('.setup.ini.bak.')]
     assert len(backups) == 1
+
+
+def test_write_creates_missing_conf(tmp_path):
+    f = tmp_path / 'new.conf'
+
+    with LMNFile(str(f), 'w') as lmn:
+        lmn.write({'section': {'enabled': True}})
+
+    with LMNFile(str(f), 'r') as lmn:
+        result = lmn.read()
+
+    assert result['section']['enabled'] is True
+    assert stat.S_IMODE(f.stat().st_mode) == 0o600
+    assert not list(tmp_path.glob('.new.conf.bak.*'))
+
+
+def test_write_uses_same_directory_atomic_replace(tmp_path, monkeypatch):
+    f = make_ini(tmp_path, '[school]\nname = Old\n')
+    original_replace = os.replace
+    replace_call = {}
+
+    def track_replace(source, destination):
+        replace_call['source'] = source
+        replace_call['destination'] = destination
+        assert os.path.dirname(source) == str(tmp_path)
+        assert f.read_text(encoding='utf-8') == '[school]\nname = Old\n'
+        original_replace(source, destination)
+
+    monkeypatch.setattr(os, 'replace', track_replace)
+
+    with LMNFile(str(f), 'r') as lmn:
+        data = lmn.read()
+        data['school']['name'] = 'New'
+        lmn.write(data)
+
+    assert replace_call['destination'] == str(f)
+    assert 'name = New' in f.read_text(encoding='utf-8')
+
+
+def test_atomic_write_preserves_permissions(tmp_path):
+    f = make_ini(tmp_path, '[school]\nname = Old\n')
+    f.chmod(0o640)
+
+    with LMNFile(str(f), 'r') as lmn:
+        data = lmn.read()
+        data['school']['name'] = 'New'
+        lmn.write(data)
+
+    assert stat.S_IMODE(f.stat().st_mode) == 0o640
+
+
+def test_atomic_write_preserves_owner_and_group(tmp_path, monkeypatch):
+    f = make_ini(tmp_path, '[school]\nname = Old\n')
+    original_metadata = f.stat()
+    original_chown = os.chown
+    chown_call = {}
+
+    def track_chown(path, uid, gid):
+        chown_call['uid'] = uid
+        chown_call['gid'] = gid
+        original_chown(path, uid, gid)
+
+    monkeypatch.setattr(os, 'chown', track_chown)
+
+    with LMNFile(str(f), 'r') as lmn:
+        data = lmn.read()
+        data['school']['name'] = 'New'
+        lmn.write(data)
+
+    assert chown_call == {
+        'uid': original_metadata.st_uid,
+        'gid': original_metadata.st_gid,
+    }
+    assert f.stat().st_uid == original_metadata.st_uid
+    assert f.stat().st_gid == original_metadata.st_gid
+
+
+def test_atomic_write_preserves_configuration_symlink(tmp_path):
+    target = make_ini(
+        tmp_path, '[school]\nname = Old\n', name='target.conf'
+    )
+    link = tmp_path / 'linked.conf'
+    link.symlink_to(target)
+
+    with LMNFile(str(link), 'r') as lmn:
+        data = lmn.read()
+        data['school']['name'] = 'New'
+        lmn.write(data)
+
+    assert link.is_symlink()
+    assert link.resolve() == target
+    assert 'name = New' in target.read_text(encoding='utf-8')
+
+
+def test_failed_replace_leaves_original_file(tmp_path, monkeypatch):
+    original = '[school]\nname = Old\n'
+    f = make_ini(tmp_path, original)
+
+    def fail_replace(source, destination):
+        raise OSError('replace failed')
+
+    monkeypatch.setattr(os, 'replace', fail_replace)
+
+    with pytest.raises(OSError, match='replace failed'):
+        with LMNFile(str(f), 'r') as lmn:
+            data = lmn.read()
+            data['school']['name'] = 'New'
+            lmn.write(data)
+
+    assert f.read_text(encoding='utf-8') == original
+    assert not list(tmp_path.glob('.setup.ini.*.tmp'))
 
 
 # ── conf extension ────────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR extends LMNFile so configuration files can be created and replaced atomically while optionally preserving exact string values. It provides the reusable configuration foundation. Necessary to create imgae.conf and match.conf 