### PR TITLE
Add LINBO hardware inventory reader

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -14,3 +14,13 @@ The manager contains a dict of all groups in the attributes `groups`. Each group
 >>> lim.groups['ubuntu'].to_dict()
 {'name': 'ubuntu', 'size': 2609718272, 'desc': 'Install LaTeX and update', 'info': '["ubuntu.qcow2" Info File]\ntimestamp="202108291639"\nimage="ubuntu.qcow2"\nimagesize="2609718272"\npartition="/dev/sda1"\npartitionsize="31457280"\n', 'reg': None, 'postsync': None, 'vdi': None, 'prestart': '#! /bin/bash\n\necho "ok"\n', 'backup': False, 'diff': False, 'timestamp': '202108291639', 'date': '29/08/2021 16:39', 'diff_image': {}, 'backups': {'03/03/2022 19:03': {'name': 'ubuntu', 'size': 0, 'desc': '', 'info': 'timestamp=202203031903\ndate=voila', 'reg': None, 'postsync': None, 'vdi': None, 'prestart': None, 'backup': True, 'diff': False, 'timestamp': '202203031903', 'date': '03/03/2022 19:03'}, '29/08/2021 16:22': {'name': 'ubuntu', 'size': 3233778176, 'desc': 'Install ZSH', 'info': '[ubuntu.qcow2 Info File]\ntimestamp=202108291622\nimage=ubuntu.qcow2\nbaseimage=/dev/sda1\npartitionsize=31457159\nimagesize=3233778176\n', 'reg': None, 'postsync': None, 'vdi': None, 'prestart': '#! /bin/bash\n\necho "ok"\n', 'backup': True, 'diff': False, 'timestamp': '202108291622', 'date': '29/08/2021 16:22'}, '29/08/2021 16:17': {'name': 'ubuntu', 'size': 3233778176, 'desc': 'Install ZSH', 'info': '[ubuntu.qcow2 Info File]\ntimestamp=202108291617\nimage=ubuntu.qcow2\nbaseimage=/dev/sda1\npartitionsize=31457159\nimagesize=3233778176\n', 'reg': None, 'postsync': None, 'vdi': None, 'prestart': '#! /bin/bash\n\necho "ok"\n', 'backup': True, 'diff': False, 'timestamp': '202108291617', 'date': '29/08/2021 16:17'}}, 'selected': False}
 ```
+
+## Hardware inventories
+
+`LinboHardwareInventoryManager` reads the `*_hwinfo.gz` files uploaded by
+LINBO clients from `/var/log/linuxmuster/linbo`. Its `list()` and `get()`
+methods combine DMI vendor and product information with the school-scoped
+client records provided by `Devices`.
+
+The manager is read-only. It does not create driver profiles or modify LINBO
+images and can therefore be used independently by API and CLI consumers.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/__init__.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/__init__.py
@@ -9,6 +9,7 @@ from .changes import *
 from .dhcp import *
 from .grub  import *
 from .grub_generator import *
+from .hardware_inventory import *
 from .host_status import *
 from .image_sync import *
 from .linbofs import *
@@ -26,6 +27,5 @@ from .wol import *
 #from .kernel import *
 #from .wlan import *
 #from .linbo_update import *
-
 
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/hardware_inventory.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/hardware_inventory.py
@@ -1,0 +1,190 @@
+"""Read DMI information uploaded by LINBO clients.
+
+LINBO stores one compressed ``<hostname>_hwinfo.gz`` file per client in
+``/var/log/linuxmuster/linbo``.  The inventory manager combines these files
+with the school-scoped client records already provided by :class:`Devices`.
+It is read-only and deliberately independent from driver profiles and hooks.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..common.checks import NameChecker
+from ..common.timestamps import get_utc_mtime
+from ..devices import Devices
+
+
+logger = logging.getLogger(__name__)
+name_checker = NameChecker()
+
+DEFAULT_HWINFO_DIR = Path("/var/log/linuxmuster/linbo")
+DEFAULT_SCHOOL = "default-school"
+MAX_COMPRESSED_HWINFO_BYTES = 8 * 1024 * 1024
+MAX_HWINFO_BYTES = 32 * 1024 * 1024
+
+_DMI_TYPE_RE = re.compile(
+    r"^[ \t]*type[ \t]+0x([0-9a-f]+)\b"
+    r"(?:[ \t]+\[[^\]\r\n]*\])?"
+    r"(?:[ \t]*:[ \t]*([0-9a-f]{2}(?:[ \t]+[0-9a-f]{2})*))?"
+    r"[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_DMI_STRING_RE = re.compile(
+    r'^[ \t]*str(\d+):[ \t]*"([^"\r\n]*)"[ \t]*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def parse_dmi(text: str) -> dict[str, str | None] | None:
+    """Return SMBIOS system vendor, product and version from hwinfo output."""
+
+    blocks = list(_DMI_TYPE_RE.finditer(text))
+    type_one_index = next(
+        (index for index, block in enumerate(blocks) if block.group(1).lower() == "01"),
+        None,
+    )
+    if type_one_index is None:
+        return None
+
+    type_one = blocks[type_one_index]
+    raw_header = type_one.group(2)
+    if raw_header is None:
+        return None
+
+    try:
+        header = bytes.fromhex(raw_header)
+    except ValueError:
+        return None
+    if len(header) < 7 or header[0] != 0x01 or header[1] < 7:
+        return None
+
+    block_end = (
+        blocks[type_one_index + 1].start()
+        if type_one_index + 1 < len(blocks)
+        else len(text)
+    )
+    block_text = text[type_one.start() : block_end]
+    strings = {
+        int(match.group(1)): match.group(2).strip()
+        for match in _DMI_STRING_RE.finditer(block_text)
+    }
+
+    def indexed_string(index: int) -> str | None:
+        if index == 0:
+            return None
+        return strings.get(index) or None
+
+    result = {
+        "vendor": indexed_string(header[4]),
+        "product": indexed_string(header[5]),
+        "version": indexed_string(header[6]),
+    }
+    return result if any(result.values()) else None
+
+
+def _read_hwinfo(path: Path) -> str:
+    """Read one gzip inventory with compressed and decompressed-size limits."""
+
+    if path.stat().st_size > MAX_COMPRESSED_HWINFO_BYTES:
+        raise ValueError(
+            "Compressed LINBO hardware inventory exceeds "
+            f"{MAX_COMPRESSED_HWINFO_BYTES} bytes"
+        )
+
+    with gzip.open(path, "rb") as stream:
+        content = stream.read(MAX_HWINFO_BYTES + 1)
+    if len(content) > MAX_HWINFO_BYTES:
+        raise ValueError(f"LINBO hardware inventory exceeds {MAX_HWINFO_BYTES} bytes")
+    return content.decode("utf-8", errors="replace")
+
+
+class LinboHardwareInventoryManager:
+    """List and read school-scoped LINBO hardware inventories."""
+
+    def __init__(
+        self,
+        school: str = DEFAULT_SCHOOL,
+        hwinfo_dir: str | Path = DEFAULT_HWINFO_DIR,
+    ) -> None:
+        if not name_checker.check_group_name(school):
+            raise ValueError(f"Invalid school name: {school}")
+
+        self.school = school
+        self.hwinfo_dir = Path(hwinfo_dir)
+        self.devices = Devices(school=school)
+
+    def _inventory_path(self, hostname: str) -> Path:
+        if not name_checker.check_host_name(hostname):
+            raise ValueError(f"Invalid hostname: {hostname}")
+
+        inventory_hostname = hostname
+        if self.school != DEFAULT_SCHOOL:
+            inventory_hostname = f"{self.school}-{hostname}"
+        return self.hwinfo_dir / f"{inventory_hostname}_hwinfo.gz"
+
+    def _read_client(self, client: Mapping[str, Any]) -> dict[str, Any] | None:
+        hostname = client.get("hostname")
+        if not isinstance(hostname, str):
+            logger.warning("Ignoring LINBO client without a valid hostname")
+            return None
+
+        try:
+            path = self._inventory_path(hostname)
+        except ValueError as error:
+            logger.warning("Ignoring LINBO client: %s", error)
+            return None
+
+        if not path.is_file():
+            return None
+
+        try:
+            dmi = parse_dmi(_read_hwinfo(path))
+        except (EOFError, OSError, ValueError) as error:
+            logger.warning(
+                "Could not read LINBO hardware inventory %s: %s",
+                path.name,
+                error,
+            )
+            return None
+
+        captured_at = get_utc_mtime(path)
+        return {
+            "hostname": hostname,
+            "school": self.school,
+            "room": client.get("room"),
+            "group": client.get("group"),
+            "mac": client.get("mac"),
+            "ip": client.get("ip"),
+            "capturedAt": captured_at.isoformat() if captured_at else None,
+            "dmi": dmi,
+        }
+
+    def list(self) -> list[dict[str, Any]]:
+        """Return readable inventories for the school's configured clients."""
+
+        inventories = []
+        for client in self.devices.get_clients():
+            inventory = self._read_client(client)
+            if inventory is not None:
+                inventories.append(inventory)
+        return inventories
+
+    def get(self, hostname: str) -> dict[str, Any] | None:
+        """Return one configured client's inventory, or ``None`` if absent."""
+
+        if not name_checker.check_host_name(hostname):
+            raise ValueError(f"Invalid hostname: {hostname}")
+
+        client = self.devices.get_client(hostname)
+        return self._read_client(client) if client is not None else None
+
+
+__all__ = [
+    "LinboHardwareInventoryManager",
+    "parse_dmi",
+]

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_hardware_inventory.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_hardware_inventory.py
@@ -1,0 +1,224 @@
+import gzip
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import linuxmusterTools.linbo.hardware_inventory as inventory_module
+from linuxmusterTools.linbo.hardware_inventory import (
+    LinboHardwareInventoryManager,
+    parse_dmi,
+)
+
+
+HWINFO = """
+============ start debug info ============
+  type 0x03 [0x0003]: 03 16 03 00 01 02 03
+       str1: "Wrong chassis vendor"
+       str2: "Wrong chassis product"
+  type 0x01 [0x0001]: 01 1b 01 00 01 02 00 03 00 e2 0e d7
+       str1: "Hewlett-Packard"
+       str2: "HP ProDesk 600 G1 TWR"
+       str3: "CZC43638T2"
+  type 0x02 [0x0002]: 02 0f 02 00 01 02 00
+       str1: "Must not replace the system vendor"
+"""
+
+
+def write_inventory(directory: Path, hostname: str, content: str = HWINFO) -> Path:
+    path = directory / f"{hostname}_hwinfo.gz"
+    path.write_bytes(gzip.compress(content.encode("utf-8")))
+    return path
+
+
+def use_devices(
+    monkeypatch: pytest.MonkeyPatch,
+    records: list[dict],
+) -> list[str]:
+    schools = []
+
+    class FakeDevices:
+        def __init__(self, school: str) -> None:
+            schools.append(school)
+
+        def get_clients(self) -> list[dict]:
+            return records
+
+        def get_client(self, hostname: str) -> dict | None:
+            return next(
+                (record for record in records if record.get("hostname") == hostname),
+                None,
+            )
+
+    monkeypatch.setattr(inventory_module, "Devices", FakeDevices)
+    return schools
+
+
+def test_parse_dmi_uses_smbios_type_one_string_indexes() -> None:
+    assert parse_dmi(HWINFO) == {
+        "vendor": "Hewlett-Packard",
+        "product": "HP ProDesk 600 G1 TWR",
+        "version": None,
+    }
+
+    reordered = """
+type 0x01 [0x0001]: 01 1b 01 00 03 01 02 04
+  str1: "Product from index one"
+  str2: "Version from index two"
+  str3: "Vendor from index three"
+  str4: "Serial number, not version"
+"""
+    assert parse_dmi(reordered) == {
+        "vendor": "Vendor from index three",
+        "product": "Product from index one",
+        "version": "Version from index two",
+    }
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        'type 0x03 [0x0003]: 03 16 03 00 01 02 03\n  str1: "Chassis"',
+        'type 0x01 [0x0001]\n  str1: "Vendor"',
+        'type 0x01 [0x0001]: 01 06 01 00 01 02\n  str1: "Vendor"',
+    ],
+)
+def test_parse_dmi_rejects_missing_or_invalid_type_one(content: str) -> None:
+    assert parse_dmi(content) is None
+
+
+def test_list_combines_devices_dmi_and_existing_timestamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inventory = write_inventory(tmp_path, "client-a")
+    captured_at = datetime(2026, 7, 10, 10, 0, tzinfo=timezone.utc)
+    os.utime(inventory, (captured_at.timestamp(), captured_at.timestamp()))
+    schools = use_devices(
+        monkeypatch,
+        [
+            {
+                "hostname": "client-a",
+                "room": "room-1",
+                "group": "win11",
+                "mac": "AA:BB:CC:DD:EE:FF",
+                "ip": "10.0.0.42",
+            },
+            {"hostname": "client-without-inventory"},
+        ],
+    )
+
+    inventories = LinboHardwareInventoryManager(
+        hwinfo_dir=tmp_path,
+    ).list()
+
+    assert schools == ["default-school"]
+    assert inventories == [
+        {
+            "hostname": "client-a",
+            "school": "default-school",
+            "room": "room-1",
+            "group": "win11",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "ip": "10.0.0.42",
+            "capturedAt": "2026-07-10T10:00:00+00:00",
+            "dmi": {
+                "vendor": "Hewlett-Packard",
+                "product": "HP ProDesk 600 G1 TWR",
+                "version": None,
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize("school", ["school-b", "school_b"])
+def test_branch_school_uses_global_linbo_inventory_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    school: str,
+) -> None:
+    write_inventory(tmp_path, f"{school}-client-a")
+    write_inventory(
+        tmp_path,
+        "client-a",
+        HWINFO.replace("Hewlett-Packard", "Wrong unprefixed inventory"),
+    )
+    schools = use_devices(monkeypatch, [{"hostname": "client-a"}])
+
+    inventory = LinboHardwareInventoryManager(
+        school=school,
+        hwinfo_dir=tmp_path,
+    ).get("client-a")
+
+    assert schools == [school]
+    assert inventory is not None
+    assert inventory["hostname"] == "client-a"
+    assert inventory["school"] == school
+    assert inventory["dmi"]["vendor"] == "Hewlett-Packard"
+
+
+def test_get_returns_none_for_unknown_client_or_missing_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    use_devices(monkeypatch, [{"hostname": "known-client"}])
+    manager = LinboHardwareInventoryManager(hwinfo_dir=tmp_path)
+
+    assert manager.get("unknown-client") is None
+    assert manager.get("known-client") is None
+
+
+def test_list_skips_corrupt_and_oversized_inventories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_inventory(tmp_path, "good")
+    (tmp_path / "broken_hwinfo.gz").write_bytes(b"not gzip")
+    max_bytes = len(HWINFO.encode("utf-8"))
+    write_inventory(tmp_path, "large", "x" * (max_bytes + 1))
+    use_devices(
+        monkeypatch,
+        [
+            {"hostname": "good"},
+            {"hostname": "broken"},
+            {"hostname": "large"},
+        ],
+    )
+    monkeypatch.setattr(inventory_module, "MAX_HWINFO_BYTES", max_bytes)
+
+    inventories = LinboHardwareInventoryManager(hwinfo_dir=tmp_path).list()
+
+    assert [inventory["hostname"] for inventory in inventories] == ["good"]
+
+
+def test_list_skips_oversized_compressed_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inventory = write_inventory(tmp_path, "large-compressed")
+    use_devices(monkeypatch, [{"hostname": "large-compressed"}])
+    monkeypatch.setattr(
+        inventory_module,
+        "MAX_COMPRESSED_HWINFO_BYTES",
+        inventory.stat().st_size - 1,
+    )
+
+    assert LinboHardwareInventoryManager(hwinfo_dir=tmp_path).list() == []
+
+
+def test_name_checker_protects_school_and_inventory_filenames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="school"):
+        LinboHardwareInventoryManager(
+            school="../school",
+            hwinfo_dir=tmp_path,
+        )
+
+    use_devices(monkeypatch, [{"hostname": "../client"}])
+    manager = LinboHardwareInventoryManager(hwinfo_dir=tmp_path)
+    assert manager.list() == []
+    with pytest.raises(ValueError, match="hostname"):
+        manager.get("../client")


### PR DESCRIPTION
 This PR adds a read-only `LinboHardwareInventoryManager`.

  It reads the hardware information already uploaded by LINBO clients and extracts the hostname, manufacturer, product name and hardware version.

  The manager provides:

  - `list()` to list available client inventories
  - `get(hostname)` to read one client inventory

  This PR does not create driver profiles, modify LINBO files or connect to clients. It only provides hardware data for later API and WebUI integration.