### PR TITLE
Add read-only LINBO driver image assignments

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -58,3 +58,24 @@ This creates `/srv/linbo/drivers/lenovo-21l4/match.conf`. Administrators may
 place an already prepared INF driver payload next to that file. Profile
 updates change only `match.conf` and leave those payload files untouched. This
 manager does not upload, extract, inspect or publish the payload yet.
+
+### Read-only image assignments
+
+`LinboImageManager` can read an optional `image.conf` from a driver profile:
+
+```ini
+[image]
+name = win11
+```
+
+```python
+from linuxmusterTools.linbo import LinboDriverManager, LinboImageManager
+
+drivers = LinboDriverManager()
+images = LinboImageManager(driver_manager=drivers)
+images.get_driver_profile_image("lenovo-21l4")
+```
+
+The former standalone package's flat `image = win11` form remains readable for
+upgrades. This interface is deliberately read-only: assigning profiles and
+generating `.driverpostsync` files follow in a separate change.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
@@ -31,6 +31,7 @@ DEFAULT_DRIVERS_BASE = Path(
     os.environ.get("DRIVERS_BASE", "/srv/linbo/drivers")
 )
 MATCH_CONF_FILENAME = "match.conf"
+IMAGE_CONF_FILENAME = "image.conf"
 MAX_MATCH_VALUE_LENGTH = 512
 MUTATION_LOCK_FILENAME = ".driver-profiles.lock"
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -1,10 +1,16 @@
 import os
 import shutil
+import stat
 import subprocess
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
+from configobj import ConfigObjError
+
+from ..common.checks import NameChecker
 from ..lmnfile import LMNFile
+from .drivers import IMAGE_CONF_FILENAME, LinboDriverManager
 from .models import ImageInfo
 
 
@@ -35,6 +41,8 @@ EXTRA_PERMISSIONS_MAPPING = {
 }
 IMAGE = "qcow2"
 DIFF_IMAGE = "qdiff"
+
+name_checker = NameChecker()
 
 def date2timestamp(date):
     return datetime.strptime(date, DATE_UI_FMT).strftime(TIMESTAMP_FMT)
@@ -373,8 +381,68 @@ class LinboImageManager:
     """
 
 
-    def __init__(self):
+    def __init__(self, driver_manager=None):
+        self.driver_manager = driver_manager or LinboDriverManager()
         self.list()
+
+    @staticmethod
+    def _validated_driver_image(image):
+        """Return an image basename supported by the LINBO driver runtime."""
+
+        if (
+            not name_checker.check_linbo_image_name(image)
+            or "." in image
+            or len(image) > 100
+        ):
+            raise ValueError(
+                "Driver image names must contain only [A-Za-z0-9_-] and be "
+                "at most 100 characters long."
+            )
+        return image
+
+    def _read_profile_assignment(self, profile):
+        """Read one already validated profile's optional image assignment."""
+
+        path = Path(profile["path"]) / IMAGE_CONF_FILENAME
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return None
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"image.conf is not a regular file: {profile['name']}")
+
+        try:
+            with LMNFile(str(path), "r", convert_values=False) as image_file:
+                data = image_file.read()
+        except ConfigObjError as error:
+            raise ValueError(
+                f"Invalid image.conf for driver profile {profile['name']}: {error}"
+            ) from error
+
+        if set(data.keys()) != {"image"} or data.inline_comments.get("image"):
+            raise ValueError(
+                "image.conf must contain one canonical [image] section or "
+                "one legacy image value."
+            )
+
+        section = data["image"]
+        if isinstance(section, str):
+            # Read compatibility for the standalone/.deb format.
+            return self._validated_driver_image(section)
+
+        if not isinstance(section, dict) or set(section.keys()) != {"name"}:
+            raise ValueError("[image] must contain exactly one name.")
+        if section.inline_comments.get("name"):
+            raise ValueError("image.conf must not contain inline comments.")
+        return self._validated_driver_image(section["name"])
+
+    def get_driver_profile_image(self, profile_name):
+        """Return a profile's image assignment, if present."""
+
+        profile = self.driver_manager.get_profile(profile_name)
+        if profile is None:
+            raise FileNotFoundError(f"Driver profile not found: {profile_name}")
+        return self._read_profile_assignment(profile)
 
     def list(self):
         """

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import pytest
+
+import linuxmusterTools.linbo.images as images_module
+from linuxmusterTools.linbo.drivers import LinboDriverManager
+from linuxmusterTools.linbo.images import LinboImageManager
+
+
+@pytest.fixture
+def environment(tmp_path, monkeypatch):
+    images_root = tmp_path / "images"
+    images_root.mkdir()
+    drivers = LinboDriverManager(tmp_path / "drivers")
+    monkeypatch.setattr(images_module, "LINBO_PATH", str(images_root))
+    return drivers, LinboImageManager(driver_manager=drivers)
+
+
+def _profile(drivers, name="model"):
+    return drivers.create_profile(name, "Vendor", "Product")
+
+
+def _image_conf(profile):
+    return Path(profile["path"]) / "image.conf"
+
+
+def test_manager_uses_injected_driver_manager(environment):
+    drivers, images = environment
+
+    assert images.driver_manager is drivers
+
+
+def test_profile_without_assignment_returns_none(environment):
+    drivers, images = environment
+    _profile(drivers)
+
+    assert images.get_driver_profile_image("model") is None
+
+
+@pytest.mark.parametrize("image", ["win11", "0012", "yes", "no"])
+def test_canonical_assignment_preserves_exact_string(environment, image):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    content = f"[image]\nname = {image}\n"
+    image_conf.write_text(content)
+
+    assert images.get_driver_profile_image("model") == image
+    assert image_conf.read_text() == content
+
+
+def test_legacy_flat_assignment_remains_readable(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    content = "# Legacy standalone assignment\nimage = win11\n"
+    image_conf.write_text(content)
+
+    assert images.get_driver_profile_image("model") == "win11"
+    assert image_conf.read_text() == content
+
+
+def test_missing_profile_is_reported(environment):
+    _, images = environment
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.get_driver_profile_image("missing")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "image = win11\nextra = value\n",
+        "[image]\nname = win11\nextra = value\n",
+        "[image] # comment\nname = win11\n",
+        "[image]\nname = win11 # comment\n",
+        "[image]\n",
+        "[image\nname = win11\n",
+        "[other]\nname = win11\n",
+        "[image]\nname = win.11\n",
+        f"[image]\nname = {'a' * 101}\n",
+    ],
+)
+def test_malformed_or_unsupported_assignment_is_rejected(environment, content):
+    drivers, images = environment
+    profile = _profile(drivers)
+    _image_conf(profile).write_text(content)
+
+    with pytest.raises(ValueError):
+        images.get_driver_profile_image("model")
+
+
+def test_symlink_image_conf_is_not_followed(environment, tmp_path):
+    drivers, images = environment
+    profile = _profile(drivers)
+    outside = tmp_path / "outside.conf"
+    outside.write_text("[image]\nname = win11\n")
+    _image_conf(profile).symlink_to(outside)
+
+    with pytest.raises(ValueError, match="not a regular file"):
+        images.get_driver_profile_image("model")
+
+    assert outside.read_text() == "[image]\nname = win11\n"
+
+
+def test_directory_image_conf_is_rejected(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    _image_conf(profile).mkdir()
+
+    with pytest.raises(ValueError, match="not a regular file"):
+        images.get_driver_profile_image("model")


### PR DESCRIPTION
  This PR adds read-only access to the optional `image.conf` of a LINBO driver profile through the existing `LinboImageManager`.

  It supports:

  - the canonical `[image]` configuration section;
  - the legacy flat `image = win11` format;
  - exact string values such as `0012`, `yes` and `no`;
  - validation of image names and configuration structure;
  - rejection of symlinks and non-regular configuration files.

  The implementation reuses `LMNFile` and the existing `NameChecker`.

  This PR is intentionally read-only. It does not create or modify `image.conf`, generate `.driverpostsync` files or change LINBO images.