### PR TITLE
Add writable LINBO driver image assignments

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -59,9 +59,9 @@ place an already prepared INF driver payload next to that file. Profile
 updates change only `match.conf` and leave those payload files untouched. This
 manager does not upload, extract, inspect or publish the payload yet.
 
-### Read-only image assignments
+### Image assignments
 
-`LinboImageManager` can read an optional `image.conf` from a driver profile:
+`LinboImageManager` manages an optional `image.conf` in each driver profile:
 
 ```ini
 [image]
@@ -73,9 +73,12 @@ from linuxmusterTools.linbo import LinboDriverManager, LinboImageManager
 
 drivers = LinboDriverManager()
 images = LinboImageManager(driver_manager=drivers)
+images.assign_driver_profile("lenovo-21l4", "win11")
 images.get_driver_profile_image("lenovo-21l4")
+images.unassign_driver_profile("lenovo-21l4")
 ```
 
 The former standalone package's flat `image = win11` form remains readable for
-upgrades. This interface is deliberately read-only: assigning profiles and
-generating `.driverpostsync` files follow in a separate change.
+upgrades and is rewritten in the canonical form by the next assignment. These
+methods only persist or remove the profile metadata. They do not generate
+`.driverpostsync` files or deliver drivers to clients yet.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
@@ -156,18 +156,28 @@ class LinboDriverManager:
                 f"Driver profile base is not a real directory: {self.base}"
             )
 
+    @contextmanager
+    def _mutation(self):
+        """Serialize one driver profile metadata mutation."""
+
+        self._ensure_base_directory()
+        with _mutation_lock(self.base):
+            yield
+
     @staticmethod
-    def _write_match_conf(path, match):
+    def _write_profile_conf(path, section, values):
+        """Write one canonical profile configuration through LMNFile."""
+
         is_new = not os.path.lexists(path)
         with LMNFile(
             str(path),
             "w",
             convert_values=False,
-        ) as match_file:
-            data = match_file.read()
+        ) as profile_file:
+            data = profile_file.read()
             data.clear()
-            data["match"] = match
-            match_file.write(data)
+            data[section] = values
+            profile_file.write(data)
         if is_new:
             path.chmod(0o644)
 
@@ -271,9 +281,7 @@ class LinboDriverManager:
 
         safe_name = _validated_profile_name(name)
         match = _validated_match(vendor, product)
-        self._ensure_base_directory()
-
-        with _mutation_lock(self.base):
+        with self._mutation():
             with os.scandir(self.base) as entries:
                 collision = any(
                     entry.name.casefold() == safe_name.casefold()
@@ -292,8 +300,9 @@ class LinboDriverManager:
                 raise DriverProfileExistsError(safe_name) from error
 
             try:
-                self._write_match_conf(
+                self._write_profile_conf(
                     profile_path / MATCH_CONF_FILENAME,
+                    "match",
                     match,
                 )
             except Exception:
@@ -311,14 +320,14 @@ class LinboDriverManager:
         match = _validated_match(vendor, product)
         if not os.path.lexists(self.base):
             raise FileNotFoundError(f"Driver profile not found: {name}")
-        self._ensure_base_directory()
-        with _mutation_lock(self.base):
+        with self._mutation():
             profile = self.get_profile(name)
             if profile is None:
                 raise FileNotFoundError(f"Driver profile not found: {name}")
 
-            self._write_match_conf(
+            self._write_profile_conf(
                 Path(profile["path"]) / MATCH_CONF_FILENAME,
+                "match",
                 match,
             )
         return self.get_profile(profile["name"])
@@ -328,8 +337,7 @@ class LinboDriverManager:
 
         if not os.path.lexists(self.base):
             return False
-        self._ensure_base_directory()
-        with _mutation_lock(self.base):
+        with self._mutation():
             profile = self.get_profile(name)
             if profile is None:
                 return False
@@ -342,7 +350,7 @@ class LinboDriverManager:
         try:
             shutil.rmtree(quarantine)
         except Exception:
-            with _mutation_lock(self.base):
+            with self._mutation():
                 if not os.path.lexists(profile_path) and os.path.lexists(quarantine):
                     quarantine.rename(profile_path)
             raise

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -444,6 +444,49 @@ class LinboImageManager:
             raise FileNotFoundError(f"Driver profile not found: {profile_name}")
         return self._read_profile_assignment(profile)
 
+    def assign_driver_profile(self, profile_name, image):
+        """Persist one driver's assignment to an existing LINBO image."""
+
+        if not os.path.lexists(self.driver_manager.base):
+            raise FileNotFoundError(
+                f"Driver profile not found: {profile_name}"
+            )
+        with self.driver_manager._mutation():
+            profile = self.driver_manager.get_profile(profile_name)
+            if profile is None:
+                raise FileNotFoundError(
+                    f"Driver profile not found: {profile_name}"
+                )
+            image = self._validated_driver_image(image)
+            if image not in self.groups:
+                raise FileNotFoundError(f"LINBO image not found: {image}")
+
+            self._read_profile_assignment(profile)
+            self.driver_manager._write_profile_conf(
+                Path(profile["path"]) / IMAGE_CONF_FILENAME,
+                "image",
+                {"name": image},
+            )
+        return {"profile": profile["name"], "image": image}
+
+    def unassign_driver_profile(self, profile_name):
+        """Remove only a driver's optional image assignment."""
+
+        if not os.path.lexists(self.driver_manager.base):
+            raise FileNotFoundError(
+                f"Driver profile not found: {profile_name}"
+            )
+        with self.driver_manager._mutation():
+            profile = self.driver_manager.get_profile(profile_name)
+            if profile is None:
+                raise FileNotFoundError(
+                    f"Driver profile not found: {profile_name}"
+                )
+            previous = self._read_profile_assignment(profile)
+            if previous is not None:
+                Path(profile["path"], IMAGE_CONF_FILENAME).unlink()
+        return {"profile": profile["name"], "image": None}
+
     def list(self):
         """
         Browse LINBO_PATH to discover all linbo images.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
@@ -24,6 +24,10 @@ def _image_conf(profile):
     return Path(profile["path"]) / "image.conf"
 
 
+def _known_image(images, name):
+    images.groups[name] = object()
+
+
 def test_manager_uses_injected_driver_manager(environment):
     drivers, images = environment
 
@@ -110,3 +114,171 @@ def test_directory_image_conf_is_rejected(environment):
 
     with pytest.raises(ValueError, match="not a regular file"):
         images.get_driver_profile_image("model")
+
+
+@pytest.mark.parametrize("image", ["win11", "0012", "yes", "no"])
+def test_assign_writes_canonical_image_conf(environment, image):
+    drivers, images = environment
+    profile = _profile(drivers)
+    _known_image(images, image)
+
+    assert images.assign_driver_profile("model", image) == {
+        "profile": "model",
+        "image": image,
+    }
+    assert _image_conf(profile).read_text() == f"[image]\nname = {image}\n"
+    assert _image_conf(profile).stat().st_mode & 0o777 == 0o644
+    assert images.get_driver_profile_image("model") == image
+
+
+def test_assign_canonicalizes_legacy_assignment(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    image_conf.write_text("# Standalone format\nimage = old\n")
+    _known_image(images, "win11")
+
+    images.assign_driver_profile("model", "win11")
+
+    assert image_conf.read_text() == (
+        "# Standalone format\n[image]\nname = win11\n"
+    )
+
+
+def test_reassign_preserves_mode_and_driver_payload(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    image_conf.write_text("[image]\nname = old\n")
+    image_conf.chmod(0o640)
+    payload = Path(profile["path"], "Network", "driver.inf")
+    payload.parent.mkdir()
+    payload.write_bytes(b"driver payload")
+    _known_image(images, "win11")
+
+    images.assign_driver_profile("model", "win11")
+
+    assert image_conf.read_text() == "[image]\nname = win11\n"
+    assert image_conf.stat().st_mode & 0o777 == 0o640
+    assert payload.read_bytes() == b"driver payload"
+
+
+def test_missing_profile_or_image_does_not_create_assignment(environment):
+    drivers, images = environment
+    _known_image(images, "win11")
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.assign_driver_profile("missing", "win11")
+    assert not drivers.base.exists()
+
+    profile = _profile(drivers)
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.assign_driver_profile("model", "missing")
+
+    assert not _image_conf(profile).exists()
+
+
+def test_missing_target_image_preserves_existing_assignment(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    content = "[image]\nname = old\n"
+    image_conf.write_text(content)
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.assign_driver_profile("model", "missing")
+
+    assert image_conf.read_text() == content
+
+
+@pytest.mark.parametrize("image", ["win.11", "a" * 101, None])
+def test_assign_rejects_unsupported_image_name(environment, image):
+    drivers, images = environment
+    profile = _profile(drivers)
+    _known_image(images, image)
+
+    with pytest.raises(ValueError):
+        images.assign_driver_profile("model", image)
+
+    assert not _image_conf(profile).exists()
+
+
+def test_assign_does_not_replace_malformed_image_conf(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    content = "[image]\nname = old\nextra = value\n"
+    image_conf.write_text(content)
+    _known_image(images, "win11")
+
+    with pytest.raises(ValueError):
+        images.assign_driver_profile("model", "win11")
+    with pytest.raises(ValueError):
+        images.unassign_driver_profile("model")
+
+    assert image_conf.read_text() == content
+
+
+def test_assign_does_not_follow_image_conf_symlink(
+    environment, tmp_path
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    outside = tmp_path / "outside.conf"
+    outside.write_text("[image]\nname = old\n")
+    _image_conf(profile).symlink_to(outside)
+    _known_image(images, "win11")
+
+    with pytest.raises(ValueError, match="not a regular file"):
+        images.assign_driver_profile("model", "win11")
+    with pytest.raises(ValueError, match="not a regular file"):
+        images.unassign_driver_profile("model")
+
+    assert _image_conf(profile).is_symlink()
+    assert outside.read_text() == "[image]\nname = old\n"
+
+
+def test_unassign_removes_only_assignment_and_is_idempotent(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_conf = _image_conf(profile)
+    image_conf.write_text("image = vanished\n")
+    payload = Path(profile["path"], "Network", "driver.inf")
+    payload.parent.mkdir()
+    payload.write_bytes(b"driver payload")
+
+    expected = {"profile": "model", "image": None}
+    assert images.unassign_driver_profile("model") == expected
+    assert images.unassign_driver_profile("model") == expected
+
+    assert not image_conf.exists()
+    assert Path(profile["path"], "match.conf").exists()
+    assert payload.read_bytes() == b"driver payload"
+
+
+def test_unassign_missing_profile_is_reported(environment):
+    drivers, images = environment
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.unassign_driver_profile("missing")
+
+    assert not drivers.base.exists()
+
+
+def test_assignment_uses_existing_driver_mutation_lock(
+    environment, tmp_path
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    lock = drivers.base / ".driver-profiles.lock"
+    lock.unlink()
+    outside = tmp_path / "outside.lock"
+    outside.write_text("keep")
+    lock.symlink_to(outside)
+    _known_image(images, "win11")
+
+    with pytest.raises(OSError):
+        images.assign_driver_profile("model", "win11")
+
+    assert not _image_conf(profile).exists()
+    assert outside.read_text() == "keep"


### PR DESCRIPTION

  This PR extends the accepted read-only driver image assignment support with two write
  operations:

  - `assign_driver_profile(profile, image)`
  - `unassign_driver_profile(profile)`

  Assignments are stored in the canonical `image.conf` format:

  ```ini
  [image]
  name = win11
