### PR TITLE
Render LINBO driver dispatchers

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -75,10 +75,14 @@ drivers = LinboDriverManager()
 images = LinboImageManager(driver_manager=drivers)
 images.assign_driver_profile("lenovo-21l4", "win11")
 images.get_driver_profile_image("lenovo-21l4")
+images.get_image_driver_profiles("win11")
+dispatcher = images.render_driverpostsync("win11")
 images.unassign_driver_profile("lenovo-21l4")
 ```
 
 The former standalone package's flat `image = win11` form remains readable for
-upgrades and is rewritten in the canonical form by the next assignment. These
-methods only persist or remove the profile metadata. They do not generate
-`.driverpostsync` files or deliver drivers to clients yet.
+upgrades and is rewritten in the canonical form by the next assignment.
+Assigned profile names can be resolved in deterministic order. The
+renderer returns the small `.driverpostsync` dispatcher expected by LINBO's
+static `linbo_driverpostsync` runtime. It does not write or replace any file;
+publishing the rendered content and delivering drivers remain separate steps.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
@@ -181,8 +181,12 @@ class LinboDriverManager:
         if is_new:
             path.chmod(0o644)
 
-    def list_profiles(self):
-        """Return every complete, valid profile sorted by name."""
+    def list_profiles(self, *, strict=False):
+        """Return every complete, valid profile sorted by name.
+
+        Raise the first profile error instead of skipping it when ``strict``
+        is true.
+        """
 
         if not os.path.lexists(self.base):
             return []
@@ -195,6 +199,8 @@ class LinboDriverManager:
             try:
                 profile = self.get_profile(candidate.name)
             except (OSError, ValueError, ConfigObjError) as error:
+                if strict:
+                    raise
                 logger.warning(
                     "Ignoring invalid driver profile %s: %s",
                     candidate.name,

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -41,6 +41,9 @@ EXTRA_PERMISSIONS_MAPPING = {
 }
 IMAGE = "qcow2"
 DIFF_IMAGE = "qdiff"
+DRIVERPOSTSYNC_MANAGED_HEADER = (
+    "# Managed-By: linuxmusterTools.linbo.driver_hooks v1"
+)
 
 name_checker = NameChecker()
 
@@ -400,6 +403,14 @@ class LinboImageManager:
             )
         return image
 
+    def _require_driver_image(self, image):
+        """Return a validated image name that is managed by LINBO."""
+
+        image = self._validated_driver_image(image)
+        if image not in self.groups:
+            raise FileNotFoundError(f"LINBO image not found: {image}")
+        return image
+
     def _read_profile_assignment(self, profile):
         """Read one already validated profile's optional image assignment."""
 
@@ -444,6 +455,45 @@ class LinboImageManager:
             raise FileNotFoundError(f"Driver profile not found: {profile_name}")
         return self._read_profile_assignment(profile)
 
+    def get_image_driver_profiles(self, image):
+        """Return the profiles assigned to an image in deterministic order."""
+
+        image = self._require_driver_image(image)
+        profiles = []
+        known_names = {}
+        for profile in self.driver_manager.list_profiles(strict=True):
+            name = profile["name"]
+            normalized = name.casefold()
+            previous = known_names.get(normalized)
+            if previous is not None and previous != name:
+                raise ValueError(
+                    "Driver profile names differ only by case: "
+                    f"{previous}, {name}"
+                )
+            known_names[normalized] = name
+            if self._read_profile_assignment(profile) == image:
+                profiles.append(name)
+        return sorted(profiles, key=lambda value: (value.casefold(), value))
+
+    def render_driverpostsync(self, image):
+        """Render the thin dispatcher for the static LINBO driver runtime."""
+
+        profiles = self.get_image_driver_profiles(image)
+        profile_comment = ", ".join(profiles) or "(none)"
+        arguments = "".join(f' "{profile}"' for profile in profiles)
+        return (
+            "#!/bin/sh\n"
+            f"{DRIVERPOSTSYNC_MANAGED_HEADER}\n"
+            f"# Image: {image}\n"
+            f"# Profiles: {profile_comment}\n\n"
+            "if ! command -v linbo_driverpostsync >/dev/null 2>&1; then\n"
+            '    echo "LINBO driver runtime is missing." >&2\n'
+            "    return 1\n"
+            "fi\n\n"
+            f'linbo_driverpostsync "{image}"{arguments}\n'
+            "return $?\n"
+        )
+
     def assign_driver_profile(self, profile_name, image):
         """Persist one driver's assignment to an existing LINBO image."""
 
@@ -457,9 +507,7 @@ class LinboImageManager:
                 raise FileNotFoundError(
                     f"Driver profile not found: {profile_name}"
                 )
-            image = self._validated_driver_image(image)
-            if image not in self.groups:
-                raise FileNotFoundError(f"LINBO image not found: {image}")
+            image = self._require_driver_image(image)
 
             self._read_profile_assignment(profile)
             self.driver_manager._write_profile_conf(

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -282,3 +283,126 @@ def test_assignment_uses_existing_driver_mutation_lock(
 
     assert not _image_conf(profile).exists()
     assert outside.read_text() == "keep"
+
+
+def test_image_profiles_include_only_assignments_for_requested_image(
+    environment,
+):
+    drivers, images = environment
+    _known_image(images, "win11")
+    _known_image(images, "other")
+    assignments = {
+        "Zulu": "[image]\nname = win11\n",
+        "alpha": "image = win11\n",
+        "Beta": "[image]\nname = win11\n",
+        "other-model": "[image]\nname = other\n",
+        "unassigned": None,
+    }
+    for name, content in assignments.items():
+        profile = _profile(drivers, name)
+        if content is not None:
+            _image_conf(profile).write_text(content)
+
+    assert images.get_image_driver_profiles("win11") == [
+        "alpha",
+        "Beta",
+        "Zulu",
+    ]
+    assert images.get_image_driver_profiles("other") == ["other-model"]
+
+
+def test_image_profiles_require_an_existing_image(environment):
+    drivers, images = environment
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        images.get_image_driver_profiles("missing")
+
+    assert not drivers.base.exists()
+
+
+def test_invalid_profile_blocks_image_profile_resolution(environment):
+    drivers, images = environment
+    _known_image(images, "win11")
+    drivers.base.mkdir()
+    (drivers.base / "incomplete").mkdir()
+
+    with pytest.raises(ValueError, match="has no match.conf"):
+        images.get_image_driver_profiles("win11")
+
+
+def test_invalid_assignment_blocks_image_profile_resolution(environment):
+    drivers, images = environment
+    _known_image(images, "win11")
+    profile = _profile(drivers)
+    _image_conf(profile).write_text("[image]\nname = win11\nextra = value\n")
+
+    with pytest.raises(ValueError, match="exactly one name"):
+        images.get_image_driver_profiles("win11")
+
+
+def test_case_colliding_profile_names_are_rejected(environment):
+    drivers, images = environment
+    _known_image(images, "win11")
+    first = _profile(drivers, "Model")
+    _image_conf(first).write_text("[image]\nname = win11\n")
+    second = drivers.base / "model"
+    second.mkdir()
+    (second / "match.conf").write_text(
+        "[match]\nvendor = Vendor\nproduct = Product\n"
+    )
+    (second / "image.conf").write_text("[image]\nname = win11\n")
+
+    with pytest.raises(ValueError, match="differ only by case"):
+        images.get_image_driver_profiles("win11")
+
+
+def test_render_driverpostsync_matches_static_runtime_contract(environment):
+    drivers, images = environment
+    _known_image(images, "win11")
+    for name in ("Zulu", "alpha", "Beta"):
+        profile = _profile(drivers, name)
+        _image_conf(profile).write_text("[image]\nname = win11\n")
+
+    content = images.render_driverpostsync("win11")
+
+    assert content == (
+        "#!/bin/sh\n"
+        "# Managed-By: linuxmusterTools.linbo.driver_hooks v1\n"
+        "# Image: win11\n"
+        "# Profiles: alpha, Beta, Zulu\n\n"
+        "if ! command -v linbo_driverpostsync >/dev/null 2>&1; then\n"
+        '    echo "LINBO driver runtime is missing." >&2\n'
+        "    return 1\n"
+        "fi\n\n"
+        'linbo_driverpostsync "win11" "alpha" "Beta" "Zulu"\n'
+        "return $?\n"
+    )
+    assert subprocess.run(
+        ["/bin/sh", "-n"],
+        input=content,
+        text=True,
+        check=False,
+    ).returncode == 0
+
+
+def test_render_driverpostsync_without_profiles_is_a_cleanup_dispatcher(
+    environment,
+):
+    drivers, images = environment
+    _known_image(images, "win11")
+
+    content = images.render_driverpostsync("win11")
+
+    assert content == (
+        "#!/bin/sh\n"
+        "# Managed-By: linuxmusterTools.linbo.driver_hooks v1\n"
+        "# Image: win11\n"
+        "# Profiles: (none)\n\n"
+        "if ! command -v linbo_driverpostsync >/dev/null 2>&1; then\n"
+        '    echo "LINBO driver runtime is missing." >&2\n'
+        "    return 1\n"
+        "fi\n\n"
+        'linbo_driverpostsync "win11"\n'
+        "return $?\n"
+    )
+    assert not drivers.base.exists()

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_drivers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_drivers.py
@@ -178,6 +178,16 @@ def test_list_profiles_returns_only_complete_valid_profiles(tmp_path):
     assert [profile["name"] for profile in manager.list_profiles()] == ["valid"]
 
 
+def test_strict_profile_listing_reports_invalid_profiles(tmp_path):
+    base = tmp_path / "drivers"
+    manager = LinboDriverManager(base)
+    manager.create_profile("valid", "Dell", "Latitude")
+    (base / "incomplete").mkdir()
+
+    with pytest.raises(ValueError, match="has no match.conf"):
+        manager.list_profiles(strict=True)
+
+
 def test_scalar_match_value_is_reported_as_invalid_configuration(tmp_path):
     base = tmp_path / "drivers"
     profile = base / "scalar"


### PR DESCRIPTION
  This adds the read-only preparation of LINBO driver dispatchers.

  - Resolve all driver profiles assigned to an existing image.
  - Return profiles in a deterministic order.
  - Render the small `.driverpostsync` dispatcher expected by `linbo_driverpostsync`.
  - Reuse the existing validators, LMNFile handling and image assignment reader.
  - Fail safely when profile or assignment metadata is invalid.
