### PR TITLE
Synchronize LINBO driver assignments and dispatchers

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -76,10 +76,7 @@ images = LinboImageManager(driver_manager=drivers)
 images.assign_driver_profile("lenovo-21l4", "win11")
 images.get_driver_profile_image("lenovo-21l4")
 images.get_image_driver_profiles("win11")
-dispatcher = images.render_driverpostsync("win11")
-hook = images.publish_driverpostsync("win11")
 images.unassign_driver_profile("lenovo-21l4")
-images.publish_driverpostsync("win11")
 ```
 
 The former standalone package's flat `image = win11` form remains readable for
@@ -90,5 +87,8 @@ static `linbo_driverpostsync` runtime. The publisher atomically writes that
 dispatcher into the image directory with LINBO's standard postsync mode. It
 refuses to replace symlinks, non-regular files or hooks without its exact
 managed header. The exact standalone v1.1.1 generator markers remain accepted
-for an in-place migration. Assignment changes and publishing remain explicit
-separate steps in this change.
+for an in-place migration. Assigning, moving or removing a profile publishes
+all affected dispatchers under the same mutation lock. If publication fails,
+the manager restores the previous image selection and republishes a safe
+dispatcher state. `render_driverpostsync()` and `publish_driverpostsync()`
+remain available as explicit inspection and repair operations for one image.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -499,8 +499,8 @@ class LinboImageManager:
         )
 
     @staticmethod
-    def _write_driverpostsync(path, content):
-        """Atomically replace one owned raw driverpostsync hook."""
+    def _validate_driverpostsync_target(path):
+        """Return existing hook metadata after validating its ownership."""
 
         image_directory = path.parent
         directory_metadata = image_directory.lstat()
@@ -547,6 +547,14 @@ class LinboImageManager:
                 raise PermissionError(
                     f"Refusing to overwrite unmanaged driverpostsync hook: {path}"
                 )
+        return target_metadata
+
+    @classmethod
+    def _write_driverpostsync(cls, path, content):
+        """Atomically replace one owned raw driverpostsync hook."""
+
+        image_directory = path.parent
+        target_metadata = cls._validate_driverpostsync_target(path)
 
         temporary = None
         try:
@@ -601,8 +609,67 @@ class LinboImageManager:
         with self.driver_manager._mutation():
             return str(self._regenerate_driverpostsync(image))
 
+    def _change_driver_assignment(self, profile, image):
+        """Change one assignment and publish every affected dispatcher."""
+
+        previous = self._read_profile_assignment(profile)
+        if previous is None and image is None:
+            return
+
+        affected = []
+        for candidate in (image, previous):
+            if candidate in self.groups and candidate not in affected:
+                affected.append(candidate)
+        for candidate in affected:
+            self.render_driverpostsync(candidate)
+            path = (
+                Path(self.groups[candidate].path)
+                / f"{candidate}.driverpostsync"
+            )
+            self._validate_driverpostsync_target(path)
+
+        assignment = Path(profile["path"]) / IMAGE_CONF_FILENAME
+        attempted = []
+        try:
+            if image is None:
+                assignment.unlink()
+            else:
+                self.driver_manager._write_profile_conf(
+                    assignment,
+                    "image",
+                    {"name": image},
+                )
+            for candidate in affected:
+                attempted.append(candidate)
+                self._regenerate_driverpostsync(candidate)
+        except Exception as error:
+            rollback_errors = []
+            try:
+                if previous is None:
+                    assignment.unlink(missing_ok=True)
+                else:
+                    self.driver_manager._write_profile_conf(
+                        assignment,
+                        "image",
+                        {"name": previous},
+                    )
+            except Exception as rollback_error:
+                rollback_errors.append(rollback_error)
+            for candidate in attempted:
+                try:
+                    self._regenerate_driverpostsync(candidate)
+                except Exception as rollback_error:
+                    rollback_errors.append(rollback_error)
+            if rollback_errors:
+                details = "; ".join(str(item) for item in rollback_errors)
+                raise RuntimeError(
+                    f"Driver assignment publication failed for {profile['name']} "
+                    f"({error}); rollback was incomplete: {details}"
+                ) from rollback_errors[0]
+            raise
+
     def assign_driver_profile(self, profile_name, image):
-        """Persist one driver's assignment to an existing LINBO image."""
+        """Assign a profile and publish all affected image dispatchers."""
 
         if not os.path.lexists(self.driver_manager.base):
             raise FileNotFoundError(
@@ -615,17 +682,11 @@ class LinboImageManager:
                     f"Driver profile not found: {profile_name}"
                 )
             image = self._require_driver_image(image)
-
-            self._read_profile_assignment(profile)
-            self.driver_manager._write_profile_conf(
-                Path(profile["path"]) / IMAGE_CONF_FILENAME,
-                "image",
-                {"name": image},
-            )
+            self._change_driver_assignment(profile, image)
         return {"profile": profile["name"], "image": image}
 
     def unassign_driver_profile(self, profile_name):
-        """Remove only a driver's optional image assignment."""
+        """Remove an assignment and publish the previous image dispatcher."""
 
         if not os.path.lexists(self.driver_manager.base):
             raise FileNotFoundError(
@@ -637,9 +698,7 @@ class LinboImageManager:
                 raise FileNotFoundError(
                     f"Driver profile not found: {profile_name}"
                 )
-            previous = self._read_profile_assignment(profile)
-            if previous is not None:
-                Path(profile["path"], IMAGE_CONF_FILENAME).unlink()
+            self._change_driver_assignment(profile, None)
         return {"profile": profile["name"], "image": None}
 
     def list(self):

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
@@ -33,6 +33,20 @@ def _known_image(images, name):
     return path
 
 
+def _fail_regeneration_once(monkeypatch, images, target):
+    original = images._regenerate_driverpostsync
+    failed = False
+
+    def fail_once(image):
+        nonlocal failed
+        if image == target and not failed:
+            failed = True
+            raise OSError(f"{target} publication failed")
+        return original(image)
+
+    monkeypatch.setattr(images, "_regenerate_driverpostsync", fail_once)
+
+
 def test_manager_uses_injected_driver_manager(environment):
     drivers, images = environment
 
@@ -259,6 +273,96 @@ def test_unassign_removes_only_assignment_and_is_idempotent(environment):
     assert not image_conf.exists()
     assert Path(profile["path"], "match.conf").exists()
     assert payload.read_bytes() == b"driver payload"
+
+
+def test_assignment_lifecycle_updates_old_and_new_dispatchers(environment):
+    drivers, images = environment
+    _profile(drivers)
+    old_path = _known_image(images, "old")
+    new_path = _known_image(images, "new")
+
+    images.assign_driver_profile("model", "old")
+    old_hook = old_path / "old.driverpostsync"
+    assert '# Profiles: model' in old_hook.read_text()
+
+    images.assign_driver_profile("model", "new")
+    new_hook = new_path / "new.driverpostsync"
+    assert '# Profiles: (none)' in old_hook.read_text()
+    assert '# Profiles: model' in new_hook.read_text()
+
+    images.unassign_driver_profile("model")
+    assert '# Profiles: (none)' in new_hook.read_text()
+
+
+def test_assignment_refuses_foreign_hook_before_writing_image_conf(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    hook = image_path / "win11.driverpostsync"
+    content = "#!/bin/sh\necho administrator hook\n"
+    hook.write_text(content)
+
+    with pytest.raises(PermissionError, match="unmanaged"):
+        images.assign_driver_profile("model", "win11")
+
+    assert not _image_conf(profile).exists()
+    assert hook.read_text() == content
+
+
+def test_reassignment_publish_failure_rolls_back_metadata_and_hooks(
+    environment, monkeypatch
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    old_path = _known_image(images, "old")
+    new_path = _known_image(images, "new")
+    images.assign_driver_profile("model", "old")
+    old_hook = old_path / "old.driverpostsync"
+    _fail_regeneration_once(monkeypatch, images, "old")
+
+    with pytest.raises(OSError, match="old publication failed"):
+        images.assign_driver_profile("model", "new")
+
+    assert _image_conf(profile).read_text() == "[image]\nname = old\n"
+    assert '# Profiles: model' in old_hook.read_text()
+    assert '# Profiles: (none)' in (
+        new_path / "new.driverpostsync"
+    ).read_text()
+
+
+def test_first_assignment_publish_failure_removes_assignment(
+    environment, monkeypatch
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    _fail_regeneration_once(monkeypatch, images, "win11")
+
+    with pytest.raises(OSError, match="win11 publication failed"):
+        images.assign_driver_profile("model", "win11")
+
+    assert not _image_conf(profile).exists()
+    assert '# Profiles: (none)' in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
+
+
+def test_unassign_publish_failure_restores_assignment(
+    environment, monkeypatch
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    images.assign_driver_profile("model", "win11")
+    _fail_regeneration_once(monkeypatch, images, "win11")
+
+    with pytest.raises(OSError, match="win11 publication failed"):
+        images.unassign_driver_profile("model")
+
+    assert _image_conf(profile).read_text() == "[image]\nname = win11\n"
+    assert '# Profiles: model' in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
 
 
 def test_unassign_missing_profile_is_reported(environment):


### PR DESCRIPTION
 This PR connects driver profile assignments with the existing dispatcher publisher.

  Assigning, moving or removing a driver profile now automatically updates all affected
  `.driverpostsync` files under the existing mutation lock.

  Rendering and hook ownership are validated before changing `image.conf`. If publication
  fails, the previous image selection is restored and all affected dispatchers are
  republished into a safe state.
