### PR TITLE
Synchronize driver assignments and dispatchers

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/README.md
@@ -87,9 +87,7 @@ images.assign_driver_profile("lenovo-21l4", "win11")
 images.get_driver_profile_image("lenovo-21l4")
 images.get_image_driver_profiles("win11")
 dispatcher = images.render_driverpostsync("win11")
-hook = images.publish_driverpostsync("win11")
 images.unassign_driver_profile("lenovo-21l4")
-images.publish_driverpostsync("win11")
 ```
 
 These public manager methods resolve the named `LinboImageGroup` and delegate
@@ -103,5 +101,10 @@ static `linbo_driverpostsync` runtime. The publisher atomically writes that
 dispatcher into the image directory with LINBO's standard postsync mode. It
 refuses to replace symlinks, non-regular files or hooks without its exact
 managed header. The exact standalone v1.1.1 generator markers remain accepted
-for an in-place migration. Assignment changes and publishing remain explicit
-separate steps in this change.
+for an in-place migration. Assigning, moving or removing a profile publishes
+all affected dispatchers under the same mutation lock. If publication fails,
+the previous assignment is restored and the affected dispatchers are
+regenerated to match it.
+`publish_driverpostsync()` remains available as an explicit repair operation.
+Assigned profiles must be unassigned before their profile directory can be
+deleted, preventing a dispatcher from retaining a stale profile name.

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/drivers.py
@@ -377,6 +377,11 @@ class LinboDriverManager:
             if profile is None:
                 return False
             profile_path = Path(profile["path"])
+            if os.path.lexists(profile_path / IMAGE_CONF_FILENAME):
+                raise ValueError(
+                    f"Driver profile {profile['name']} is assigned; "
+                    "unassign it before deleting."
+                )
             quarantine = self.base / (
                 f".{profile['name']}.deleting-{uuid.uuid4().hex}"
             )
@@ -501,8 +506,8 @@ class WindowsDrivers:
         )
 
     @staticmethod
-    def _write_driverpostsync(path, content):
-        """Atomically replace one owned raw driverpostsync hook."""
+    def _validate_driverpostsync_target(path):
+        """Return existing hook metadata after validating its ownership."""
 
         image_directory = path.parent
         directory_metadata = image_directory.lstat()
@@ -549,6 +554,14 @@ class WindowsDrivers:
                 raise PermissionError(
                     f"Refusing to overwrite unmanaged driverpostsync hook: {path}"
                 )
+        return target_metadata
+
+    @classmethod
+    def _write_driverpostsync(cls, path, content):
+        """Atomically replace one owned raw driverpostsync hook."""
+
+        image_directory = path.parent
+        target_metadata = cls._validate_driverpostsync_target(path)
 
         temporary = None
         try:
@@ -587,14 +600,25 @@ class WindowsDrivers:
                 except FileNotFoundError:
                     pass
 
+    def _driverpostsync_path(self):
+        """Return this image group's driverpostsync hook path."""
+
+        return (
+            Path(self.image_group.path)
+            / f"{self.image_group.name}.driverpostsync"
+        )
+
+    def _preflight_driverpostsync(self):
+        """Validate this image's configuration and existing hook target."""
+
+        self.render_driverpostsync()
+        self._validate_driverpostsync_target(self._driverpostsync_path())
+
     def _regenerate_driverpostsync(self):
         """Render and publish this image's managed driverpostsync hook."""
 
         content = self.render_driverpostsync()
-        path = (
-            Path(self.image_group.path)
-            / f"{self.image_group.name}.driverpostsync"
-        )
+        path = self._driverpostsync_path()
         self._write_driverpostsync(path, content)
         return path
 
@@ -604,8 +628,85 @@ class WindowsDrivers:
         with self.driver_manager._mutation():
             return str(self._regenerate_driverpostsync())
 
-    def assign_profile(self, profile_name):
-        """Persist one driver profile's assignment to this image."""
+    @staticmethod
+    def _write_profile_assignment(driver_manager, profile, image):
+        """Set one assignment while the caller holds the mutation lock."""
+
+        path = Path(profile["path"]) / IMAGE_CONF_FILENAME
+        if image is None:
+            path.unlink(missing_ok=True)
+            return
+        driver_manager._write_profile_conf(
+            path,
+            "image",
+            {"name": _validated_driver_image(image)},
+        )
+
+    @classmethod
+    def _apply_assignment(
+        cls,
+        driver_manager,
+        profile,
+        previous_image,
+        image,
+        affected,
+    ):
+        """Change one assignment and publish every affected dispatcher."""
+
+        if previous_image is None and image is None:
+            return
+
+        assignment = Path(profile["path"]) / IMAGE_CONF_FILENAME
+        previous_metadata = (
+            assignment.lstat() if previous_image is not None else None
+        )
+        for windows_drivers in affected:
+            windows_drivers._preflight_driverpostsync()
+
+        attempted = []
+        try:
+            cls._write_profile_assignment(driver_manager, profile, image)
+            for windows_drivers in affected:
+                attempted.append(windows_drivers)
+                windows_drivers._regenerate_driverpostsync()
+        except Exception as error:
+            rollback_errors = []
+            try:
+                cls._write_profile_assignment(
+                    driver_manager,
+                    profile,
+                    previous_image,
+                )
+                if previous_metadata is not None:
+                    restored = assignment.stat()
+                    if (
+                        restored.st_uid != previous_metadata.st_uid
+                        or restored.st_gid != previous_metadata.st_gid
+                    ):
+                        os.chown(
+                            assignment,
+                            previous_metadata.st_uid,
+                            previous_metadata.st_gid,
+                        )
+                    assignment.chmod(stat.S_IMODE(previous_metadata.st_mode))
+            except Exception as rollback_error:
+                rollback_errors.append(rollback_error)
+            for windows_drivers in attempted:
+                try:
+                    windows_drivers._regenerate_driverpostsync()
+                except Exception as rollback_error:
+                    rollback_errors.append(rollback_error)
+            if rollback_errors:
+                details = "; ".join(str(item) for item in rollback_errors)
+                raise RuntimeError(
+                    "Driver assignment publication failed for "
+                    f"{profile['name']} ({error}); rollback was incomplete: "
+                    f"{details}"
+                ) from rollback_errors[0]
+            raise
+
+    def _change_own_assignment(self, profile_name, assigned):
+        """Change only this image group's assignment under one lock."""
 
         if not os.path.lexists(self.driver_manager.base):
             raise FileNotFoundError(
@@ -618,52 +719,36 @@ class WindowsDrivers:
                     f"Driver profile not found: {profile_name}"
                 )
             image = _validated_driver_image(self.image_group.name)
-
-            self._read_profile_assignment(profile)
-            self.driver_manager._write_profile_conf(
-                Path(profile["path"]) / IMAGE_CONF_FILENAME,
-                "image",
-                {"name": image},
-            )
-        return {"profile": profile["name"], "image": image}
-
-    @classmethod
-    def remove_profile_assignment(
-        cls,
-        driver_manager,
-        profile_name,
-        expected_image=None,
-    ):
-        """Remove one optional assignment, optionally checking its image."""
-
-        if not os.path.lexists(driver_manager.base):
-            raise FileNotFoundError(
-                f"Driver profile not found: {profile_name}"
-            )
-        with driver_manager._mutation():
-            profile = driver_manager.get_profile(profile_name)
-            if profile is None:
-                raise FileNotFoundError(
-                    f"Driver profile not found: {profile_name}"
-                )
-            previous = cls._read_profile_assignment(profile)
-            if (
-                expected_image is not None
-                and previous not in (None, expected_image)
-            ):
+            previous_image = self._read_profile_assignment(profile)
+            if previous_image not in (None, image):
+                if assigned:
+                    raise ValueError(
+                        f"Driver profile {profile['name']} is assigned to "
+                        f"{previous_image}; use LinboImageManager to move it."
+                    )
                 raise ValueError(
                     f"Driver profile {profile['name']} is assigned to "
-                    f"{previous}, not {expected_image}."
+                    f"{previous_image}, not {image}."
                 )
-            if previous is not None:
-                Path(profile["path"], IMAGE_CONF_FILENAME).unlink()
-        return {"profile": profile["name"], "image": None}
+            target_image = image if assigned else None
+            affected = [self] if assigned or previous_image is not None else []
+            self._apply_assignment(
+                self.driver_manager,
+                profile,
+                previous_image,
+                target_image,
+                affected,
+            )
+        return profile, target_image
+
+    def assign_profile(self, profile_name):
+        """Assign a profile to this image and publish its dispatcher."""
+
+        profile, image = self._change_own_assignment(profile_name, True)
+        return {"profile": profile["name"], "image": image}
 
     def unassign_profile(self, profile_name):
-        """Remove a driver profile's optional assignment to this image."""
+        """Remove this image's profile assignment and publish its hook."""
 
-        return self.remove_profile_assignment(
-            self.driver_manager,
-            profile_name,
-            expected_image=self.image_group.name,
-        )
+        profile, _ = self._change_own_assignment(profile_name, False)
+        return {"profile": profile["name"], "image": None}

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/images.py
@@ -343,7 +343,7 @@ class LinboImageGroup:
         return self.windows_drivers.publish_driverpostsync()
 
     def assign_driver_profile(self, profile_name):
-        """Persist one driver profile's assignment to this image."""
+        """Assign one driver profile to this image."""
 
         return self.windows_drivers.assign_profile(profile_name)
 
@@ -462,28 +462,51 @@ class LinboImageManager:
 
         return self._require_driver_group(image).publish_driverpostsync()
 
-    def assign_driver_profile(self, profile_name, image):
-        """Assign a profile through its target image group."""
+    def _change_driver_assignment(self, profile_name, image, *, unassign=False):
+        """Change one assignment and coordinate all affected image groups."""
 
-        # Preserve the established public error order: profile before image.
         if not os.path.lexists(self.driver_manager.base):
             raise FileNotFoundError(
                 f"Driver profile not found: {profile_name}"
             )
-        if self.driver_manager.get_profile(profile_name) is None:
-            raise FileNotFoundError(
-                f"Driver profile not found: {profile_name}"
+        with self.driver_manager._mutation():
+            profile = self.driver_manager.get_profile(profile_name)
+            if profile is None:
+                raise FileNotFoundError(
+                    f"Driver profile not found: {profile_name}"
+                )
+            target = None if unassign else self._require_driver_group(image)
+            if target is not None:
+                image = target.name
+            else:
+                image = None
+            previous_image = _WindowsDrivers._read_profile_assignment(profile)
+            previous = self.groups.get(previous_image)
+            affected = []
+            for group in (target, previous):
+                if group is not None and group.windows_drivers not in affected:
+                    affected.append(group.windows_drivers)
+            _WindowsDrivers._apply_assignment(
+                self.driver_manager,
+                profile,
+                previous_image,
+                image,
+                affected,
             )
-        return self._require_driver_group(image).assign_driver_profile(
-            profile_name
-        )
+        return {"profile": profile["name"], "image": image}
+
+    def assign_driver_profile(self, profile_name, image):
+        """Assign a profile and publish all affected image dispatchers."""
+
+        return self._change_driver_assignment(profile_name, image)
 
     def unassign_driver_profile(self, profile_name):
-        """Remove a profile assignment through the image-group domain."""
+        """Remove an assignment and publish the previous image dispatcher."""
 
-        return _WindowsDrivers.remove_profile_assignment(
-            self.driver_manager,
+        return self._change_driver_assignment(
             profile_name,
+            None,
+            unassign=True,
         )
 
     def list(self):

--- a/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/linbo/pytests/test_driver_image_assignments.py
@@ -45,6 +45,25 @@ def _known_image(images, name):
     return path
 
 
+def _fail_regeneration_once(monkeypatch, images, target):
+    windows_drivers = images.groups[target].windows_drivers
+    original = windows_drivers._regenerate_driverpostsync
+    failed = False
+
+    def fail_once():
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise OSError(f"{target} publication failed")
+        return original()
+
+    monkeypatch.setattr(
+        windows_drivers,
+        "_regenerate_driverpostsync",
+        fail_once,
+    )
+
+
 def test_manager_uses_injected_driver_manager(environment):
     drivers, images = environment
 
@@ -71,8 +90,8 @@ def test_image_groups_use_injected_driver_manager(environment):
 
 def test_image_group_owns_assignment_interface(environment):
     drivers, images = environment
-    profile = _profile(drivers)
-    _known_image(images, "win11")
+    _profile(drivers)
+    image_path = _known_image(images, "win11")
     group = images.groups["win11"]
 
     assert group.assign_driver_profile("model") == {
@@ -81,19 +100,27 @@ def test_image_group_owns_assignment_interface(environment):
     }
     assert images.get_driver_profile_image("model") == "win11"
     assert group.get_driver_profiles() == ["model"]
+    assert "# Profiles: model" in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
     assert group.unassign_driver_profile("model") == {
         "profile": "model",
         "image": None,
     }
+    assert "# Profiles: (none)" in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
 
 
-def test_image_group_does_not_remove_another_groups_assignment(environment):
+def test_image_group_does_not_change_another_groups_assignment(environment):
     drivers, images = environment
     profile = _profile(drivers)
     _known_image(images, "win11")
     _known_image(images, "ubuntu")
     images.groups["ubuntu"].assign_driver_profile("model")
 
+    with pytest.raises(ValueError, match="use LinboImageManager"):
+        images.groups["win11"].assign_driver_profile("model")
     with pytest.raises(ValueError, match="ubuntu, not win11"):
         images.groups["win11"].unassign_driver_profile("model")
 
@@ -324,6 +351,136 @@ def test_unassign_removes_only_assignment_and_is_idempotent(environment):
     assert not image_conf.exists()
     assert Path(profile["path"], "match.conf").exists()
     assert payload.read_bytes() == b"driver payload"
+
+
+def test_assignment_lifecycle_updates_old_and_new_dispatchers(environment):
+    drivers, images = environment
+    _profile(drivers)
+    old_path = _known_image(images, "old")
+    new_path = _known_image(images, "new")
+
+    images.assign_driver_profile("model", "old")
+    old_hook = old_path / "old.driverpostsync"
+    assert "# Profiles: model" in old_hook.read_text()
+    old_hook.write_text(
+        "#!/bin/sh\n"
+        "# Managed-By: linuxmusterTools.linbo.driver_hooks v1\n"
+        "outdated\n"
+    )
+    images.assign_driver_profile("model", "old")
+    assert old_hook.read_text() == images.render_driverpostsync("old")
+
+    images.assign_driver_profile("model", "new")
+    new_hook = new_path / "new.driverpostsync"
+    assert "# Profiles: (none)" in old_hook.read_text()
+    assert "# Profiles: model" in new_hook.read_text()
+
+    images.unassign_driver_profile("model")
+    assert "# Profiles: (none)" in new_hook.read_text()
+
+
+def test_assigned_profile_must_be_unassigned_before_deletion(environment):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    images.assign_driver_profile("model", "win11")
+
+    with pytest.raises(ValueError, match="unassign it before deleting"):
+        drivers.delete_profile("model")
+
+    assert Path(profile["path"]).is_dir()
+    images.unassign_driver_profile("model")
+    assert drivers.delete_profile("model") is True
+    assert "# Profiles: (none)" in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
+
+
+@pytest.mark.parametrize("foreign_image", ["old", "new"])
+def test_move_refuses_foreign_hook_before_changing_assignment(
+    environment,
+    foreign_image,
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    old_path = _known_image(images, "old")
+    new_path = _known_image(images, "new")
+    images.assign_driver_profile("model", "old")
+    hook = {"old": old_path, "new": new_path}[foreign_image] / (
+        f"{foreign_image}.driverpostsync"
+    )
+    content = "#!/bin/sh\necho administrator hook\n"
+    hook.write_text(content)
+
+    with pytest.raises(PermissionError, match="unmanaged"):
+        images.assign_driver_profile("model", "new")
+
+    assert _image_conf(profile).read_text() == "[image]\nname = old\n"
+    assert hook.read_text() == content
+
+
+@pytest.mark.parametrize("failed_image", ["new", "old"])
+def test_move_publish_failure_restores_assignment_and_both_hooks(
+    environment,
+    monkeypatch,
+    failed_image,
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    old_path = _known_image(images, "old")
+    new_path = _known_image(images, "new")
+    images.assign_driver_profile("model", "old")
+    _fail_regeneration_once(monkeypatch, images, failed_image)
+
+    with pytest.raises(OSError, match=f"{failed_image} publication failed"):
+        images.assign_driver_profile("model", "new")
+
+    assert _image_conf(profile).read_text() == "[image]\nname = old\n"
+    assert "# Profiles: model" in (
+        old_path / "old.driverpostsync"
+    ).read_text()
+    assert "# Profiles: (none)" in (
+        new_path / "new.driverpostsync"
+    ).read_text()
+
+
+def test_first_assignment_publish_failure_removes_assignment(
+    environment,
+    monkeypatch,
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    _fail_regeneration_once(monkeypatch, images, "win11")
+
+    with pytest.raises(OSError, match="win11 publication failed"):
+        images.assign_driver_profile("model", "win11")
+
+    assert not _image_conf(profile).exists()
+    assert "# Profiles: (none)" in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
+
+
+def test_unassign_publish_failure_restores_assignment_mode_and_hook(
+    environment,
+    monkeypatch,
+):
+    drivers, images = environment
+    profile = _profile(drivers)
+    image_path = _known_image(images, "win11")
+    images.assign_driver_profile("model", "win11")
+    _image_conf(profile).chmod(0o640)
+    _fail_regeneration_once(monkeypatch, images, "win11")
+
+    with pytest.raises(OSError, match="win11 publication failed"):
+        images.unassign_driver_profile("model")
+
+    assert _image_conf(profile).read_text() == "[image]\nname = win11\n"
+    assert _image_conf(profile).stat().st_mode & 0o777 == 0o640
+    assert "# Profiles: model" in (
+        image_path / "win11.driverpostsync"
+    ).read_text()
 
 
 def test_unassign_missing_profile_is_reported(environment):


### PR DESCRIPTION
  This PR keeps driver profile assignments and generated `.driverpostsync`
  dispatchers consistent.

  - `LinboImageManager` resolves the source and target image groups and
    coordinates the cross-image transaction.
  - `WindowsDrivers` reuses the existing `LMNFile` writer, mutation lock,
    renderer, ownership checks and atomic publisher.
  - Assigning, moving or unassigning a profile automatically republishes all
    affected dispatchers.
  - Publication failures restore the previous assignment and regenerate the
    affected dispatchers.
  - Direct image-group moves are rejected and must use `LinboImageManager`.
  - Assigned profiles must be unassigned before they can be deleted.

  ## Files

  - `drivers.py`: assignment writing, hook preflight, publication and rollback
  - `images.py`: thin source/target image coordination
  - `linbo/README.md`: updated assignment lifecycle documentation
  - `test_driver_image_assignments.py`: lifecycle and rollback coverage
