### PR TITLE
Let linuxmusterTools import without a configured linuxmuster.net

### DIFF
--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/pytests/test_samba.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/pytests/test_samba.py
@@ -12,6 +12,10 @@ it is intentionally left untested here. parse_log_level() is pure and
 independent of any of that, so it is fully covered below.
 """
 
+import importlib
+from subprocess import CalledProcessError
+
+import linuxmusterTools.lmnconfig.samba as samba_module
 from linuxmusterTools.lmnconfig.samba import parse_log_level
 
 
@@ -46,3 +50,35 @@ def test_last_bare_int_wins_for_general():
 def test_extra_whitespace_is_ignored():
     result = parse_log_level('   1   auth_audit:2   ')
     assert result == {'general': 1, 'auth_audit': 2}
+
+
+# ---------------------------------------------------------------------------
+# Import without a Samba installation
+# ---------------------------------------------------------------------------
+
+def _reload_samba_with_check_output(monkeypatch, raising):
+    """Re-execute samba.py with a check_output that fails the given way."""
+    import subprocess
+
+    monkeypatch.setattr(subprocess, 'check_output', raising)
+    return importlib.reload(samba_module)
+
+
+def test_import_survives_missing_net_binary(monkeypatch):
+    def _no_binary(*args, **kwargs):
+        raise FileNotFoundError(2, 'No such file or directory', '/usr/bin/net')
+
+    reloaded = _reload_samba_with_check_output(monkeypatch, _no_binary)
+
+    assert reloaded.SHARES_LIST == []
+    assert reloaded.DFS == {}
+
+
+def test_import_survives_failing_net_call(monkeypatch):
+    def _fails(*args, **kwargs):
+        raise CalledProcessError(1, ['/usr/bin/net', 'conf', 'list'])
+
+    reloaded = _reload_samba_with_check_output(monkeypatch, _fails)
+
+    assert reloaded.SHARES_LIST == []
+    assert reloaded.DFS == {}

--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/pytests/test_sophomorix.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/pytests/test_sophomorix.py
@@ -234,3 +234,22 @@ def test_sophomorix_conf_file_found_reads_data_attribute(monkeypatch, fake_lmnfi
     # Note: SophomorixConf reads config.data (not config.read()), unlike the
     # other classes in this module.
     assert config.data == canned
+
+
+# ---------------------------------------------------------------------------
+# SophomorixIni without a sophomorix installation
+# ---------------------------------------------------------------------------
+
+def test_sophomorix_ini_without_role_user_section_gives_empty_roles(monkeypatch):
+    # ConfigParser.read() silently ignores a missing file, so an unconfigured
+    # machine leaves the parser with nothing but the DEFAULT section. Reading
+    # ROLE_USER unguarded raised KeyError and made the whole package
+    # unimportable off-server.
+    monkeypatch.setattr(
+        sophomorix_module.ConfigParser, 'read', lambda self, *args, **kwargs: []
+    )
+
+    ini = SophomorixIni()
+
+    assert ini.userrole == []
+    assert ini.computerrole == []

--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/samba.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/samba.py
@@ -2,7 +2,7 @@ import logging
 import os
 from configparser import ConfigParser
 from configobj import ConfigObj
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output
 from io import StringIO
 
 
@@ -57,7 +57,11 @@ except Exception as e:
 
 DFS = {}
 
-config = ConfigObj(StringIO(check_output(["/usr/bin/net", "conf", "list"], shell=False).decode()))
+try:
+    config = ConfigObj(StringIO(check_output(["/usr/bin/net", "conf", "list"], shell=False).decode()))
+except (OSError, CalledProcessError) as e:
+    logger.error(f"Can not read the samba share configuration: {str(e)}. Is linuxmuster.net installed and configured ?")
+    config = ConfigObj()
 
 SHARES_LIST = list(config.keys())
 

--- a/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/sophomorix.py
+++ b/usr/lib/python3/dist-packages/linuxmusterTools/lmnconfig/sophomorix.py
@@ -36,6 +36,8 @@ class SophomorixIni:
     def __init__(self):
         self.path = "/usr/share/sophomorix/devel/sophomorix.ini"
         self.data = ConfigParser(delimiters=("=",), dict_type=MultiOrderedDict, strict=False)
+        if not os.path.isfile(self.path):
+            logger.warning(f"No sophomorix ini found at {self.path}. Is sophomorix installed and configured ?")
         self.data.read(self.path)
         self.sections = list(self.data.keys())
 
@@ -56,7 +58,7 @@ class SophomorixIni:
             'thinclient',
             'iponly',
         ]
-        self.userrole = list(self.dict['ROLE_USER'].keys())
+        self.userrole = list(self.dict.get('ROLE_USER', {}).keys())
 
     @staticmethod
     def sanitize(value):


### PR DESCRIPTION
`linuxmusterTools` cannot be imported on a machine that has no configured linuxmuster.net, because two module-level side effects assume one is present:

- `lmnconfig/samba.py` runs `/usr/bin/net conf list` at import time, unguarded — `FileNotFoundError` where samba is not installed.
- `lmnconfig/sophomorix.py` reads the `ROLE_USER` section of `/usr/share/sophomorix/devel/sophomorix.ini` — `ConfigParser.read()` silently ignores the missing file, so the lookup raises `KeyError`.

Importing anything from `linuxmusterTools.linbo` reaches both, through `linbo.config` → `devices` → `lmnconfig`.

The visible consequence is the test suite: `linuxmusterTools/lmnconfig/pytests/` does not fail off-server, it **fails to collect**. `test_samba.py` already records this in its module docstring — *"computed as a module-level side effect at import time … not re-testable/mockable per test case, so it is intentionally left untested here"*. Since no workflow runs the tests, this is only visible to someone trying to run them on a workstation.

## What changed

Both sites now behave like the code directly beside them, which already guards the same class of problem — the `smb.conf` read in `samba.py` sits in a `try/except`, and `SchoolConfig` checks `os.path.isfile` before opening:

- A missing or failing `net` leaves `SHARES_LIST` empty and `DFS` empty, and logs the reason at error level, in the wording the neighbouring handler already uses.
- A missing `sophomorix.ini` warns, and `userrole` falls back to an empty list via `.get()`.

**Behaviour on a configured server is unchanged** — both paths only trigger where the command or the file is absent.

## Tests

The 38 existing `lmnconfig` tests pass. Three new ones cover the added paths: import surviving a missing `net` binary, import surviving a `net` call that exits non-zero, and `SophomorixIni` with no `ROLE_USER` section.

Reverting the two source files while keeping the tests reproduces the original failure — the suite stops at collection with `FileNotFoundError: '/usr/bin/net'`, which is the point of the change.

I did not touch the version; that is the maintainers' `bumpversion` step.
